### PR TITLE
advanced/exporters: fix code block end

### DIFF
--- a/docs/advanced/exporters.md
+++ b/docs/advanced/exporters.md
@@ -22,7 +22,7 @@ optional arguments:
   -S, --supported       Shows supported matrix of targets and toolchains
   -v, --verbose         Verbose diagnostic output
   -vv, --very_verbose   Very verbose diagnostic output
-  ```
+```
 
 # Adding export support for a target
 


### PR DESCRIPTION
The triple back quote ending the code block is misplaced. Extra spaces removed.