### PR TITLE
Add captions to Handbook images

### DIFF
--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -142,12 +142,12 @@ It is often useful to see the values of variables in your program at a given tim
 
 For Windows:
 
-<span class="images">[![Video tutorial](http://img.youtube.com/vi/jAMTXK9HjfU/0.jpg)](http://www.youtube.com/watch?v=jAMTXK9HjfU&feature=youtu.be&t=31s)</span>
+<span class="images">[![Video tutorial](http://img.youtube.com/vi/jAMTXK9HjfU/0.jpg)](http://www.youtube.com/watch?v=jAMTXK9HjfU&feature=youtu.be&t=31s)<span>Watch how to debug using printf() on Windows</span></span>
 
 
 For Mac:
 
-<span class="images">[![Video tutorial](http://img.youtube.com/vi/IR8Di53AGSk/0.jpg)](http://www.youtube.com/watch?v=IR8Di53AGSk&feature=youtu.be&t=34s)</span>
+<span class="images">[![Video tutorial](http://img.youtube.com/vi/IR8Di53AGSk/0.jpg)](http://www.youtube.com/watch?v=IR8Di53AGSk&feature=youtu.be&t=34s)<span>Watch how to debug using printf() on Mac</span></span>
 
 ## What's next
 

--- a/docs/collab/collab_intro.md
+++ b/docs/collab/collab_intro.md
@@ -32,7 +32,7 @@ Update
 
 The most basic (and the most popular) usage of the collaboration system is the traditional workflow in which one author develops a project, then multiple users import and use it.
 
-<span class="images">![](images/basic_collab.png)</span>
+<span class="images">![](images/basic_collab.png)<span>Many developers can use code that one author wrote</span></span>
 
 When you import a repository, you are making a clone of a public repository in your private workspace. An imported repository can either be a whole program or a library for a program, and can contain dependencies to other repositories. For example, a library may need another library in order to work. All dependencies will be imported for you automatically when you import a repository.
 
@@ -44,15 +44,15 @@ To import a repository, simply click the Import link on the repository's page on
 
 While browsing a program or a library, you will receive notifications of new versions in the Browser panel under the Summary tab:
 
-<span class="images">![](images/updates.png)</span>
+<span class="images">![](images/updates.png)<span>Viewing the program description</span></span>
 
 It is also possible to view detailed information about the new changes in the Revisions panel. The top list represents the local repository revisions, where revision numbers marked in green are outgoing revisions, currently not present in the remote repository:
 
-<span class="images">![](images/green_revisions.png)</span>
+<span class="images">![](images/green_revisions.png)<span>The Revisions panel highlights local changes that are not yet in the remote repository</span></span>
 
 The bottom list represents the remote repository revisions currently not present in your local repository. Just like with local revisions, you can click on revisions in the remote list to see change sets and individual changes per file.
 
-<span class="images">![](images/incoming_revisions.png)</span>
+<span class="images">![](images/incoming_revisions.png)<span>Viewing remote revisions not yet in your local repository</span></span>
 
 To get the latest version of the code, simply click the **Update** button.
 
@@ -64,21 +64,21 @@ Unless you are the author of the imported repository or have developer access (s
 
 1. Open the context menu of the imported program or library and click **Publish**:
 
-	<span class="images">![](images/publish.png)</span>
+	<span class="images">![](images/publish.png)<span>Making changes from your private workspace public</span></span>
 
 1. You are prompted to publish to the linked remote repository:
 
-	<span class="images">![](images/publish_prompt.png)</span>
+	<span class="images">![](images/publish_prompt.png)<span>Publishing your changes to the remote repository</span></span>
 
 1. As you do not have permission to publish to the repository, click the **Fork...** button:
 
-	<span class="images">![](images/fork.png)</span>
+	<span class="images">![](images/fork.png)<span>Forking and describing your forked repository</span></span>
 
 1. Your repository, with all its changes, is published to your profile on the mbed.org website.
 
 The forking process is identical to the [code publishing](publishing_code.md) workflow, with the exception that the forked repository will be recognized as a fork of the original or imported one:
 
-<span class="images">![](images/fork_indication.png)</span>
+<span class="images">![](images/fork_indication.png)<span>Identifying a forked repository and its ancestor</span></span>
 
 <span class="notes">**Note:** When you fork a repository, the local repository in your workspace is linked to the forked remote repository - the URL changes to the forked repository's URL. You can change the URL by clicking the pencil icon next to the URL in the Revisions panel.</span>
 
@@ -90,11 +90,11 @@ If someone forks one of your repositories and modifies it, you can easily pull i
 
 1. Click the `Update From...` button:
 
-	<span class="images">![](images/update_from.png)</span>
+	<span class="images">![](images/update_from.png)<span>Updating your original repository from another user's remote fork</span></span>
 
 1. Enter the URL of the published repository you want to pull changes from:
 
-	<span class="images">![](images/repo_url.png)</span>
+	<span class="images">![](images/repo_url.png)<span>Choosing the repository whose changes you want to pull</span></span>
 
 1. Click OK. The changes are pulled into your local repository.
 
@@ -110,15 +110,15 @@ To compare the local repository with the remote one:
 
 1. Open the Revisions panel and click the "Compare With ..." button on the bottom panel:
 
-	<span class="images">![](images/compare_repo.png)</span>
+	<span class="images">![](images/compare_repo.png)<span>Comparing a local and a remote repository</span></span>
 
 1. Enter the URL of the remote repository you want to compare with.
 
-	<span class="images">![](images/repo_url_compare.png)</span>
+	<span class="images">![](images/repo_url_compare.png)<span>Choosing the remote repository to compare</span></span>
 
 1. Click OK. The repositories are compared, and the Revisions panel reflects the comparison mode:
 
-	<span class="images">![](images/comparing_repos.png)</span>
+	<span class="images">![](images/comparing_repos.png)<span>Viewing the comparison in the Revisions panel</span></span>
 
 You can view the remote changes by clicking on revisions in the bottom (remote) panel. You can then
 

--- a/docs/collab/mult_auth.md
+++ b/docs/collab/mult_auth.md
@@ -2,7 +2,7 @@
 
 Repositories on [developer.mbed.org](https://developer.mbed.org) are not limited to one author for each repository. Instead, several authors may have the right to publish to the same repository, allowing them to collaborate on a project. Other users, who may be interested in using the project's code but are not concerned with the individual authors, can interact with a single repository.
 
-<span class="images">![](images/mult_authors.png)</span>
+<span class="images">![](images/mult_authors.png)<span>Developers can use code that multiple authors created</span></span>
 
 ## Adding a new author to your repository
 
@@ -12,7 +12,7 @@ To grant permission for another author to commit to your repository:
 
 1. Start typing a username in the **Developers** box to add the user to the list:
 
-	<span class="images">![](images/privacy_settings.png)</span>
+	<span class="images">![](images/privacy_settings.png)<span>Allowing other users to add to your repository</span>
 
 ## Day to day usage
 
@@ -26,7 +26,7 @@ When there are changes that exist on the public repository but not in your works
 
 To bring the changes into your own workspace repository, click the **Update** button in the Revisions panel for the relevant program or library:
 
-<span class="images">![](images/multi_revision_history.png)</span>
+<span class="images">![](images/multi_revision_history.png)<span>Updating your private workspace with changes from the public repository</span></span>
 
 ### Merging your changes (if necessary)
 
@@ -36,7 +36,7 @@ However, if two people have worked at the same time on a program or library, it 
 
 When you pull the changes into your workspace, you will see something like this:
 
-<span class="images">![](images/changes_to_merge.png)</span>
+<span class="images">![](images/changes_to_merge.png)<span>Viewing branches with merge conflicts</span></span>
 
 The Revisions panel shows one person's changes diverging from another person's changes. This is called *a branch*. 
 
@@ -50,11 +50,11 @@ However, if two or more people have edited the same line of the same file, a mer
 
 When a merge conflict occurs, you get a warning. Also, all the files that have conflicts in them are highlighted:
 
-<span class="images">![](images/conflict_files.png)</span>
+<span class="images">![](images/conflict_files.png)<span>A highlighted file has a merge conflict</span></span>
 
 Open the file(s) in conflict and look for something like this:
 
-<span class="images">![](images/conflict_review.png)</span>
+<span class="images">![](images/conflict_review.png)<span>Identifying the lines in the source code that have conflicts</span></span>
 
 Wherever there is a conflict, Mercurial annotates the source code with markings showing your changes and other people's changes. You then have to choose one person's version, or blend the two. When you have finished, remove the ``<<<<``, ``>>>`` and ``===`` marks, and save the file. 
 
@@ -66,7 +66,7 @@ After you merge the code, you have to commit it. This makes the join between two
 
 Once you commit, your Revisions pane will look something like this:
 
-<span class="images">![](images/commit_merge.png)</span>
+<span class="images">![](images/commit_merge.png)<span>Viewing merged branches in the Revisions pane</span></span>
 
 You can see the two branches coming back together at "merged revision 1 with revision 2".
 

--- a/docs/collab/publishing_code.md
+++ b/docs/collab/publishing_code.md
@@ -12,13 +12,13 @@ If you want to share your work:
 
 1. Click **Publish** from the right-click context menu in the mbed Online Compiler:
 
-	<span class="images">![](images/publish.png)</span>
+	<span class="images">![](images/publish.png)<span>Using the Online Compiler to publish a program</span></span>
 
 1. If you have uncommitted changes, you will be prompted to commit your work. 
 
 1. If this is the first time you have published this program or library, you will see a dialog box like this one:
 
-	<span class="images">![](images/publish_deatils.png)</span>
+	<span class="images">![](images/publish_deatils.png)<span>Completing the dialog box with a description of the program</span></span>
 
 1. Enter a description of what you are publishing.
 
@@ -40,4 +40,4 @@ That copies your private repository to the mbed public website, where other user
 
 The end result is that a published repository is an **exact copy** of your program or library as it exists in your workspace. This ensures that the code works as expected when another user imports your code.
 
-<span class="images">![](images/published_repo.png)</span>
+<span class="images">![](images/published_repo.png)<span>The public copy of the program on your mbed website profile is identical to the one from your private workspace</span></span>

--- a/docs/collab/pull_requests.md
+++ b/docs/collab/pull_requests.md
@@ -18,11 +18,11 @@ To create a pull request:
 
 1. When you publish a fork of another repository, the mbed developer site displays the ancestor repository under **Repository details**. If you are the repository owner, an additional **Create Pull Request** button will be displayed on top.
 
-	<span class="images">![](images/repo_details.png)</span>
+	<span class="images">![](images/repo_details.png)<span>A forked repository shows the details of its ancestry</span></span>
 
 1. Click the **Create Pull Request** button. The **Create Pull Request** page opens, showing the URLs of the forked and the ancestor repositories:
 
-	<span class="images">![](images/create_pull_request.png)</span>
+	<span class="images">![](images/create_pull_request.png)<span>Creating a pull request with a forked repostiory</span></span>
 
 1. You can change the remote repository URL if you want to send a pull request to another related repository. The form will validate the repository URL addresses as you type or paste, and will warn if either of them is wrong, missing or unrelated. It will also check whether the forked repository (on the left) has changes that aren't present in the remote repository (on the right).
 
@@ -32,7 +32,7 @@ To create a pull request:
 
 The pull request is added to the **Pull Requests** page of the repository, and an email is sent to the repository owners with the title and description you specified.
 
-<span class="images">![](images/pull_request_created.png)</span>
+<span class="images">![](images/pull_request_created.png)<span>Sending the pull request</span></span>
 
 ### Editing an existing pull request
 
@@ -52,13 +52,13 @@ When a pull request is sent to a repository to which you're author or co-author,
 
 You can also see all existing pull requests by visiting the repository page and clicking on the **Pull Requests** tab:
 
-<span class="images">![](images/open_pull_requests.png)</span>
+<span class="images">![](images/open_pull_requests.png)<span>Viewing all open pull requests by using the Pull Requests tab</span></span>
 
 <span class="tips">**Tip:** This will only list the open pull requests. To view all pull requests, including the closed ones (accepted or rejected) click the **Show all pull requests** button.</span>
 
 On each pull request page you can discuss changes, coding standards and so on before accepting or rejecting the request. Once closed, you won't be able to add more comments.
 
-<span class="images">![](images/review_pull_request.png)</span>
+<span class="images">![](images/review_pull_request.png)<span>Reviewing and commenting on a pull request</span></span>
 
 To quickly close a pull request without reviewing it, click the **Close** button.
 
@@ -76,13 +76,13 @@ To review a pull request:
 
 1.  The mbed Compiler suggests an import name based on your repository name and a `_pullrequest` suffix, to remind you that this was imported as part of a pull request. You're free to change the name:
 
-	<span class="images">![](images/import_pull_request.png)</span>
+	<span class="images">![](images/import_pull_request.png)<span>The Online Compiler's default import name suggestion</span></span>
 
 1. Click "Import".
 
 1. The pull request is imported to your workspace, and the Revisions panel opens:
 	
-	<span class="images">![](images/revision_history_pull_request.png)</span>
+	<span class="images">![](images/revision_history_pull_request.png)<span>Viewing the pull request in the Revisions panel</span></span>
 
 Newly introduced revisions are marked in green. These are the proposed changes - the ones you are being asked to pull. To review individual changes, click on the files list on the right. 
 
@@ -92,15 +92,15 @@ The mbed Online Compiler remembers the pull request status of an imported progra
 
 Click the **Accept** button in the bottom panel, and an accept confirmation dialog opens:
 
-<span class="images">![](images/accept_pull_request.png)</span>
+<span class="images">![](images/accept_pull_request.png)<span>Accepting a pull request makes its changes public</span></span>
 
 You can clean up the imported program by checking the **Delete this program when complete (cleanup)** button.
 
 Accepting a pull request publishes to your repository both the contents of that pull request, and any changes you made to the pull request. It also marks the pull request as accepted:
 
-<span class="images">![](images/pull_request_accepted.png)</span>
+<span class="images">![](images/pull_request_accepted.png)<span>Another dialog box appears and informs you that your acceptance of the pull request was successful</span></span>
 
-<span class="images">![](images/pull_request_closed.png)</span>
+<span class="images">![](images/pull_request_closed.png)<span>Viewing the pull request after accepting it</span></span>
 
 
 ### Rejecting a pull request
@@ -109,7 +109,7 @@ If you choose to reject the pull request:
 
 1. Click the **Reject** button in the bottom panel. A confirmation dialog opens:
 
-	<span class="images">![](images/reject_pull_request.png)</span>
+	<span class="images">![](images/reject_pull_request.png)<span>Commenting on a pull request rejection</span></span>
 
 1. Enter a comment explaining the rejection. 
 

--- a/docs/collab/versions.md
+++ b/docs/collab/versions.md
@@ -2,7 +2,7 @@
 
 You can use the mbed Online Compiler's version control features to let you version, branch and merge code. It will show a nice representation of the state of your project history:
  
-<span class="images">![](images/revision_history_overview.png)</span>
+<span class="images">![](images/revision_history_overview.png)<span>The Online Compiler shows the current version of your project and your project's history</span></span>
 
 The approach should be familiar to those of you with experience of distributed version control models (as used by Mercurial and Git). Each program and library has its own local repository, so you can commit and perform actions on it within your own workspace (such as switching, branching and showing changes). 
 
@@ -33,7 +33,7 @@ There is also the option to *discard* your working copy, and *revert* your worki
 
 You can see the changes between your current working copy and the previous revision, and changes between revisions:
 
-<span class="images">![](images/compare_revisions.png)</span>
+<span class="images">![](images/compare_revisions.png)<span>The File changes section shows differences between this revision and the previous one</span></span>
 
 ## Subrepositories and synchronization
 

--- a/docs/dev_tools/online_comp.md
+++ b/docs/dev_tools/online_comp.md
@@ -6,7 +6,7 @@ The compiler is always available on [https://developer.mbed.org/compiler/](https
 
 ## Video summary
 
-<span class="images">[![Video tutorial](http://img.youtube.com/vi/NKSlkUcoOjY/0.jpg)](http://www.youtube.com/watch?v=L5TcmFFD0iw)</span>
+<span class="images">[![Video tutorial](http://img.youtube.com/vi/NKSlkUcoOjY/0.jpg)](http://www.youtube.com/watch?v=L5TcmFFD0iw)<span>Watch how to use the mbed Online Compiler</span></span>
 
 ## Importing code to the compiler
 

--- a/docs/getting_started/blinky_cli.md
+++ b/docs/getting_started/blinky_cli.md
@@ -4,7 +4,7 @@
 
 <span class="tips">**Tip:** the video assumes you've already [installed mbed CLI](#installing-mbed-cli-and-a-toolchain).
 
-<span class="images">[![Video tutorial](http://img.youtube.com/vi/PI1Kq9RSN_Y/0.jpg)](https://www.youtube.com/watch?v=PI1Kq9RSN_Y)</span>
+<span class="images">[![Video tutorial](http://img.youtube.com/vi/PI1Kq9RSN_Y/0.jpg)](https://www.youtube.com/watch?v=PI1Kq9RSN_Y)<span>Watch how to create your first application on mbed CLI</span></span>
 
 ## Blinky's code
 


### PR DESCRIPTION
Add captions to all images in latest version of Handbook

Note: Captions format weird in preview, but I merged one as a test, and it looks fine on the page