### PR TITLE
Update porting_guide.md

### DIFF
--- a/docs/advanced/porting_guide.md
+++ b/docs/advanced/porting_guide.md
@@ -86,5 +86,6 @@ PWMOUT           |   pwmout_api.h
 RTC              |   rtc_api.h
 SLEEP            |   sleep_api.h
 SPI SPISLAVE     |   spi_api.h
-TRNG             |  trng_api.h
+TRNG             |   trng_api.h
+FLASH            |   flash_api.h
 ```


### PR DESCRIPTION
Check in the initial docs for mbed-os bootloader support.