### PR TITLE
Correct online compiler compile menu options

### DIFF
--- a/docs/dev_tools/online_comp.md
+++ b/docs/dev_tools/online_comp.md
@@ -93,8 +93,8 @@ To select a board as the build target:
 
 The **Compile** menu offers five options:
 
-1. **Compile:** builds your code and downloads a binary file. Current program only.
-1. **Compile All:** same as *compile*, but for all programs.
+1. **Compile:** builds code that you have modified since your last compile and downloads the resulting binary file.
+1. **Compile All:** same as *compile*, but rebuilds all source code, even if it hasn't changed since the last compile.
 1. **Build Only:** compiles your code but doesn't download the result.
 1. **Compile Macros:** defines additional macros at compile time.
 1. **Update Docs**: see the [guide for documenting APIs](https://docs.mbed.com/docs/mbed-os-api-reference/en/5.1/APIs/API_Documentation/).


### PR DESCRIPTION
The difference between the first two compiler options isn't what
programs in your workspace are built but whether an incremental or
clean build is performed.

Addresses issue #132.