### PR TITLE
Remove CMSIS-DAP which is confused with DAPLink

### DIFF
--- a/docs/advanced/DAP.md
+++ b/docs/advanced/DAP.md
@@ -1,8 +1,5 @@
 # DAPLink
 
-
-## DAPLink
-
 DAPlink is an open source project that implements the embedded firmware required for a Cortex debug probe. The project is hosted on GitHub and is published under an Apache 2.0 license, making it attractive for commercial developments.
 
 The software project is complemented by a series of reference designs for creating the DAPLink debug probe hardware, which is available [here](https://docs.mbed.com/docs/mbed-hardware-development-kit/en/latest/).

--- a/docs/advanced/DAP.md
+++ b/docs/advanced/DAP.md
@@ -1,4 +1,4 @@
-# CMSIS-DAP and DAPLink
+# DAPLink
 
 
 ## DAPLink

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ pages:
 - ['cont/code_style.md', 'Publishing libraries and contributing to mbed OS', 'Code style guide']
 - ['cont/adding_exporters.md', 'Publishing libraries and contributing to mbed OS', 'Adding exporters']
 - ['advanced/intro.md', 'Advanced tutorials', 'Introduction to the advanced tutorials']
-- ['advanced/DAP.md', 'Advanced tutorials', 'CMSIS-DAP and DAPLink']
+- ['advanced/DAP.md', 'Advanced tutorials', 'DAPLink']
 - ['advanced/config_system.md', 'Advanced tutorials', 'Compile time configuration']
 - ['advanced/exporters.md', 'Advanced tutorials', 'Exporters']
 - ['advanced/mbed_targets.md', 'Advanced tutorials', 'Adding and configuring targets']


### PR DESCRIPTION
Remove CMSIS-DAP which is confused with DAPLink, otherwise we need give more description for CMSIS-DAP and the difference between CMSIS-DAP and DAPLink.