### PR TITLE
Improve memory stats page

### DIFF
--- a/docs/advanced/runtime_stats.md
+++ b/docs/advanced/runtime_stats.md
@@ -1,6 +1,6 @@
 # Runtime statistics
 
-mbed OS 5 provides various runtime statistics to help characterize resource usage. This allows easy identification of potential problems, such as a stack close to overflowing. The metrics currently supported are available for the [heap](#heap-stats) and the [stack](#stack-stats).
+mbed OS 5 provides various runtime statistics to help characterize resource usage. This allows easy identification of potential problems, such as a stack close to overflowing. The metrics currently supported are available for the [heap](#heap-statistics) and the [stack](#stack-statistics).
 
 ## Heap statistics
 
@@ -8,16 +8,16 @@ Heap statistics provide exact information about the number of bytes dynamically 
 
 To enable heap stats:
 
-1. Add the command-line flag ```-DMBED_HEAP_STATS_ENABLED=1```. 
-2. Use the function ``mbed_stats_heap_get()`` to take a snapshot of heap stats. 
+1. Add the command-line flag `-DMBED_HEAP_STATS_ENABLED=1`.
+2. Use the function `mbed_stats_heap_get()` to take a snapshot of heap stats.
 
 <span class="notes">**Note**: This function is available even when the heap stats are not enabled, but always returns zero for all fields.</span>
 
 ### Example use cases
 
-* Getting worst case memory usage, ```max_size```, to properly size MCU RAM. 
-* Detecting program memory leaks by the current size allocated (```current_size```) or number of allocations in use (```alloc_cnt```).
-* Use ``alloc_fail_cnt `` to check if allocations have been failing, and if so, how many.
+* Getting worst case memory usage, `max_size`, to properly size MCU RAM.
+* Detecting program memory leaks by the current size allocated (`current_size`) or number of allocations in use (`alloc_cnt`).
+* Use `alloc_fail_cnt` to check if allocations have been failing, and if so, how many.
 
 ### Example program using heap statistics
 
@@ -49,41 +49,42 @@ int main(void)
 ### Side effects of enabling heap statistics
 
 * An additional 8 bytes of overhead for each memory allocation.
-* The function ```realloc``` will never reuse the buffer it is resizing.
+* The function `realloc` will never reuse the buffer it is resizing.
 * Memory allocation is slightly slower due to the added bookkeeping.
 
 ## Stack statistics
 
-Stack stats provide information on the allocated stack size of a thread and the worst case stack usage. Any thread on the system can be queried for stack information. 
+Stack stats provide information on the allocated stack size of a thread and the worst case stack usage. Any thread on the system can be queried for stack information.
 
-To enable heap stats, add the command-line flag ```-DMBED_STACK_STATS_ENABLED=1```.
+To enable heap stats, add the command-line flag `-DMBED_STACK_STATS_ENABLED=1`.
+
+There are two functions you can use to access the stack stats:
+* `mbed_stats_stack_get` calculates combined stack informations for all threads.
+* `mbed_stats_stack_get_each` provides stack informations for each thread separately.
+
+<span class="notes">**Note**: These functions are available even when the stack stats are not enabled, but always returns zero for all fields.</span>
+
+### Example use cases
+
+* Using `max_size` to calibrate stack sizes for each thread.
+* Detecting which stack is close to overflowing.
 
 ### Example program using stack statistics
 
 ```
 #include "mbed.h"
-#include "cmsis_os.h"
+#include "mbed_stats.h"
 
 int main(void)
 {
     printf("Starting stack stats example\r\n");
 
-    osThreadId main_id = osThreadGetId();
+    int cnt = osThreadGetCount();
+    mbed_stats_stack_t *stats = (mbed_stats_stack_t*) malloc(cnt * sizeof(mbed_stats_stack_t));
 
-    osEvent info;
-    info = _osThreadGetInfo(main_id, osThreadInfoStackSize);
-    if (info.status != osOK) {
-        error("Could not get stack size");
+    cnt = mbed_stats_stack_get_each(stats, cnt);
+    for (int i = 0; i < cnt; i++) {
+        printf("Thread: 0x%X, Stack size: %u, Max stack: %u\r\n", stats[i].thread_id, stats[i].reserved_size, stats[i].max_size);
     }
-    uint32_t stack_size = (uint32_t)info.value.v;
-    info = _osThreadGetInfo(main_id, osThreadInfoStackMax);
-    if (info.status != osOK) {
-        error("Could not get max stack");
-    }
-    uint32_t max_stack = (uint32_t)info.value.v;
-
-    printf("Stack used %li of %li bytes\r\n", max_stack, stack_size);
 }
 ```
-<span class="notes">**Note:** The stack statistics API is experimental and will change.</span>
-


### PR DESCRIPTION
Runtime memory stats page was outdated and wasn't correct. This PR improves the docs, cleans up the syntax and make sure the instructions are up to date.

@AnotherButler @c1728p9 