### PR TITLE
Add porting note for LED and button naming

### DIFF
--- a/docs/refs/porting/mbed_os_targets.md
+++ b/docs/refs/porting/mbed_os_targets.md
@@ -56,11 +56,7 @@ The next step to port a target is to enable the test harness dependencies. To ru
 
 Implement the api declared in `mbed-os/hal/gpio_api.h`. You must define the struct `gpio_t`. This struct is commonly defined in an `objects.h` file within the `mbed-os/targets/TARGET_VENDOR/`, `mbed-os/targets/TARGET_VENDOR/TARGET_MCU_FAMILY` or `mbed-os/targets/TARGET_VENDOR/TARGET_MCU_FAMILY/TARGET_MCUNAME` directories.
 
-You should define the Physical LEDs and switches in the target's `PinNames.h` file. LED and switch names begin incrementing at 1 and follow the convention `LED1...LEDn` and `BUTTON1...BUTTONn`. You should also provide software definitions for colored LEDs following the convention 
-`LED_[COLOR]`
-such as 
-`LED_RED`
-. You can see an example [here](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h#L198).
+You should define the Physical LEDs and switches in the target's `PinNames.h` file. LED and switch names begin incrementing at 1 and follow the convention `LED1...LEDn` and `BUTTON1...BUTTONn`. You can see an example [here](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h#L198).
 
 ##### Microsecond ticker
 

--- a/docs/refs/porting/mbed_os_targets.md
+++ b/docs/refs/porting/mbed_os_targets.md
@@ -56,6 +56,12 @@ The next step to port a target is to enable the test harness dependencies. To ru
 
 Implement the api declared in `mbed-os/hal/gpio_api.h`. You must define the struct `gpio_t`. This struct is commonly defined in an `objects.h` file within the `mbed-os/targets/TARGET_VENDOR/`, `mbed-os/targets/TARGET_VENDOR/TARGET_MCU_FAMILY` or `mbed-os/targets/TARGET_VENDOR/TARGET_MCU_FAMILY/TARGET_MCUNAME` directories.
 
+You should define the Physical LEDs and switches in the target's `PinNames.h` file. LED and switch names begin incrementing at 1 and follow the convention `LED1...LEDn` and `BUTTON1...BUTTONn`. You should also provide software definitions for colored LEDs following the convention 
+`LED_[COLOR]`
+such as 
+`LED_RED`
+. You can see an example [here](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h#L198).
+
 ##### Microsecond ticker
 
 The microsecond ticker is a system resource that many APIs use. The microsecond ticker needs a one microsecond resolution and uses a free-running hardware counter or timer with match register. Implement the API declared in `mbed-os\hal\us_ticker_api.h`.


### PR DESCRIPTION
Add a porting note on physical LED and Button naming conventions to address [this issue](https://github.com/ARMmbed/mbed-os/issues/4880#issuecomment-323544403).

Open to any additions to this segment.

@AnotherButler 