### PR TITLE
expand AnalogIn Description

### DIFF
--- a/docs/refs/api/drivers/AnalogIn.md
+++ b/docs/refs/api/drivers/AnalogIn.md
@@ -1,6 +1,6 @@
 #### AnalogIn
 
-Use the AnalogIn API to read an external voltage applied to an analog input pin. The voltage is read as a fraction of the system voltage as a floating point value from `0.0` to `1.0` . So if you have a 3.3V system and the voltage applied is 1.65V then the value read by `AnalogIn()` would be `0.5`. 
+Use the AnalogIn API to read an external voltage applied to an analog input pin. The voltage is read as a fraction of the system voltage as a floating point value from `0.0`(VSS) to `1.0`(VCC) . So if you have a 3.3V system and the voltage applied is 1.65V then the value read by `AnalogIn()` would be `0.5`. 
 
 **Tips:**
 

--- a/docs/refs/api/drivers/AnalogIn.md
+++ b/docs/refs/api/drivers/AnalogIn.md
@@ -1,10 +1,10 @@
 #### AnalogIn
 
-Use the AnalogIn API to read an external voltage applied to an analog input pin.
+Use the AnalogIn API to read an external voltage applied to an analog input pin. The voltage is read as a fraction of the system voltage as a floating point value from `0.0` to `1.0` . So if you have a 3.3V system and the voltage applied is 1.65V then the value read by `AnalogIn()` would be `0.5`. 
 
 **Tips:**
 
-* Only certain pins are capable of making these measurements, so check the documentation for compatible pins.
+* Only certain pins are capable of making these measurements, so check the pinmap of your board for compatible pins.
 * For more information on what it takes to convert an analog signal to its digital representation, see [http://en.wikipedia.org/wiki/Analog-to-digital_converter](http://en.wikipedia.org/wiki/Analog-to-digital_converter).   
 
 ##### API
@@ -28,9 +28,3 @@ Control an R/C servo with analog input.
 This example shows AnalogIn reading 16-bit normalized samples.
 
 [![View code](https://www.mbed.com/embed/?url=https://developer.mbed.org/teams/mbed_example/code/AnalogIn_ex_2/)](https://developer.mbed.org/teams/mbed_example/code/AnalogIn_ex_2/file/cb98929b3895/main.cpp)
-
-###### Example three
-
-The example below shows a visual volt meter using LEDs.
-
-[![View code](https://www.mbed.com/embed/?url=https://developer.mbed.org/teams/mbed_example/code/AnalogIn_ex_3/)](https://developer.mbed.org/teams/mbed_example/code/AnalogIn_ex_3/file/267d01ecb3ec/main.cpp)

--- a/docs/refs/api/drivers/AnalogIn.md
+++ b/docs/refs/api/drivers/AnalogIn.md
@@ -1,6 +1,6 @@
 #### AnalogIn
 
-Use the AnalogIn API to read an external voltage applied to an analog input pin. The voltage is read as a fraction of the system voltage as a floating point value from `0.0`(VSS) to `1.0`(VCC) . So if you have a 3.3V system and the voltage applied is 1.65V then the value read by `AnalogIn()` would be `0.5`. 
+Use the AnalogIn API to read an external voltage applied to an analog input pin. `AnalogIn()` reads the voltage as a fraction of the system voltage. The value is a floating point from `0.0`(VSS) to `1.0`(VCC). For example, if you have a 3.3V system and the applied voltage is 1.65V, then `AnalogIn()` reads `0.5` as the value. 
 
 **Tips:**
 


### PR DESCRIPTION
The description is insufficient. Expanding for fuller explanation. 

Further removing Example 3 as it does nothing to add explanation or deeper understanding to the API. The code is not commented and is confusing. 

I would suggest pruning both the remaining examples (1 and 2) as they are likewise not terribly useful, but i'll leave them to be addressed at a later date.