### PR TITLE
Add sleep API documentation

### DIFF
--- a/docs/refs/api/platform/sleep.md
+++ b/docs/refs/api/platform/sleep.md
@@ -1,0 +1,102 @@
+#### Sleep
+
+There is only one sleep function in the Mbed OS 5.6
+
+```c++
+void sleep();
+```
+
+This function invokes Sleep manager that is introduced below.
+
+It is invoked in the idle loop by default. This default behaviour can be overwritten by attaching a different the idle hook function pointer.
+
+
+```c++
+void new_idle_loop()
+{
+    // do nothing
+}
+
+void main()
+{
+    rtos_attach_idle_hook(&new_idle_loop);
+}
+```
+
+##### Sleep modes
+
+There are two available sleep modes:
+
+1. Sleep mode
+
+    The system clock to the core is stopped until a reset or an interrupt occurs. This eliminates dynamic power used by the processor, memory systems and buses. The processor, peripheral and memory state are maintained, and the peripherals continue to work and can generate interrupts.
+
+    The processor can be woken up by any internal peripheral interrupt or external pin interrupt.
+
+    The wake-up time should be less than 10 us.
+
+2. Deep sleep mode 
+
+    This processor is setup ready for deep sleep, and sent to sleep. This mode
+    has the same sleep features as sleep plus it powers down peripherals and high speed clocks. All state is still maintained. 
+    The processor can only be woken up by lp ticker, RTC, an external interrupt on a pin or a watchdog timer.
+
+    The wake-up time should be less than 10 ms.
+
+##### Latency
+
+The sleep modes introduce some interrupt + wake-up latencies that might affect the application. The times are as follows:
+
+Sleep latency - up to 10 microseconds
+Deep sleep latency - up to 10 milliseconds
+
+##### Sleep manager
+
+The sleep manager provides API to control sleep modes. Deep sleep might introduce some power savings that can affect an application, for instance high speed clock dependent drivers.
+
+`DeepSleepLock` class provides RAII object for disabling sleep, or explicit lock/unlock methods. To not let an application to enter deep sleep, invoke `DeepSleepLock()::lock()` method. As soon as an application is ready for the deep sleep, allow it by invoking `DeepSleepLock::unlock()` method.
+
+These mbed OS drivers contain locking deep sleep:
+
+- `Ticker`
+- `Timeout`
+- `Timer`
+- `SPI`
+- `I2C`
+- `CAN`
+- `SerialBase`
+
+### Example
+
+SPI asynchronous transfer with deep sleep locking
+
+```c++
+
+SPI::transfer(const Type *tx_buffer, int tx_length, Type *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE)
+{
+    if (spi_active(&_spi)) {
+        return queue_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
+    }
+    // This driver requires high speed clock, needs to waits for complete flag set via a callback to unblock the deep sleep
+    sleep_manager_lock_deep_sleep();
+    start_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
+    return 0;
+}
+
+
+void SPI::irq_handler_asynch(void)
+{
+    int event = spi_irq_handler_asynch(&_spi);
+    if (_callback && (event & SPI_EVENT_ALL)) {
+        _callback.call(event & SPI_EVENT_ALL);
+    }
+    if (event & (SPI_EVENT_ALL | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE)) {
+        // all data should be written now, unlock the deep sleep
+        sleep_manager_unlock_deep_sleep();
+#if TRANSACTION_QUEUE_SIZE_SPI
+        // SPI peripheral is free (event happend), dequeue transaction
+        dequeue_transaction();
+#endif
+    }
+}
+```

--- a/docs/refs/api/platform/sleep.md
+++ b/docs/refs/api/platform/sleep.md
@@ -1,15 +1,14 @@
 #### Sleep
 
-There is only one sleep function in the Mbed OS 5.6
+There is only one sleep function in Mbed OS 5.6
 
 ```c++
 void sleep();
 ```
 
-This function invokes Sleep manager that is introduced below.
+This function invokes sleep manager, which we introduce below.
 
-It is invoked in the idle loop by default. This default behaviour can be overwritten by attaching a different the idle hook function pointer.
-
+The idle loop invokes sleep manager by default. You can overwrite this default behaviour by attaching a different idle hook function pointer.
 
 ```c++
 void new_idle_loop()
@@ -29,34 +28,32 @@ There are two available sleep modes:
 
 1. Sleep mode
 
-    The system clock to the core is stopped until a reset or an interrupt occurs. This eliminates dynamic power used by the processor, memory systems and buses. The processor, peripheral and memory state are maintained, and the peripherals continue to work and can generate interrupts.
+    The system clock to the core stops until a reset or an interrupt occurs. This eliminates dynamic power that the processor, memory systems and buses use. This mode maintains the processor, peripheral and memory state, and the peripherals continue to work and can generate interrupts.
 
-    The processor can be woken up by any internal peripheral interrupt or external pin interrupt.
+    You can wake up the processor by any internal peripheral interrupt or external pin interrupt.
 
     The wake-up time should be less than 10 us.
 
 2. Deep sleep mode 
 
-    This processor is setup ready for deep sleep, and sent to sleep. This mode
-    has the same sleep features as sleep plus it powers down peripherals and high speed clocks. All state is still maintained. 
-    The processor can only be woken up by lp ticker, RTC, an external interrupt on a pin or a watchdog timer.
+    This processor is set up ready for deep sleep, and sent to sleep. This mode has the same sleep features as sleep, and it also powers down peripherals and high speed clocks. This mode maintains all state. You can only wake up the processor by lp ticker, RTC, an external interrupt on a pin or a watchdog timer.
 
     The wake-up time should be less than 10 ms.
 
 ##### Latency
 
-The sleep modes introduce some interrupt + wake-up latencies that might affect the application. The times are as follows:
+The sleep modes introduce some interrupt and wake-up latencies that might affect the application. The times are:
 
-Sleep latency - up to 10 microseconds
-Deep sleep latency - up to 10 milliseconds
+- Sleep latency - up to 10 microseconds.
+- Deep sleep latency - up to 10 milliseconds.
 
 ##### Sleep manager
 
 The sleep manager provides API to control sleep modes. Deep sleep might introduce some power savings that can affect an application, for instance high speed clock dependent drivers.
 
-`DeepSleepLock` class provides RAII object for disabling sleep, or explicit lock/unlock methods. To not let an application to enter deep sleep, invoke `DeepSleepLock()::lock()` method. As soon as an application is ready for the deep sleep, allow it by invoking `DeepSleepLock::unlock()` method.
+The `DeepSleepLock` class provides RAII object for disabling sleep, or explicit lock/unlock methods. To prevent an application from entering deep sleep, invoke `DeepSleepLock()::lock()` method. As soon as an application is ready for the deep sleep, allow it by invoking the `DeepSleepLock::unlock()` method.
 
-These mbed OS drivers contain locking deep sleep:
+These Mbed OS drivers contain locking deep sleep:
 
 - `Ticker`
 - `Timeout`
@@ -68,7 +65,7 @@ These mbed OS drivers contain locking deep sleep:
 
 ### Example
 
-SPI asynchronous transfer with deep sleep locking
+This example shows SPI asynchronous transfer with deep sleep locking.
 
 ```c++
 

--- a/docs/refs/api/platform/sleep.md
+++ b/docs/refs/api/platform/sleep.md
@@ -32,20 +32,9 @@ There are two available sleep modes:
 
     You can wake up the processor by any internal peripheral interrupt or external pin interrupt.
 
-    The wake-up time should be less than 10 us.
-
 2. Deep sleep mode 
 
     This processor is set up ready for deep sleep, and sent to sleep. This mode has the same sleep features as sleep, and it also powers down peripherals and high speed clocks. This mode maintains all state. You can only wake up the processor by lp ticker, RTC, an external interrupt on a pin or a watchdog timer.
-
-    The wake-up time should be less than 10 ms.
-
-##### Latency
-
-The sleep modes introduce some interrupt and wake-up latencies that might affect the application. The times are:
-
-- Sleep latency - up to 10 microseconds.
-- Deep sleep latency - up to 10 milliseconds.
 
 ##### Sleep manager
 

--- a/docs/refs/api/platform/sleep.md
+++ b/docs/refs/api/platform/sleep.md
@@ -52,13 +52,13 @@ These Mbed OS drivers contain locking deep sleep:
 - `CAN`
 - `SerialBase`
 
-### Sleep API
-
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.6/api/DeepSleepLock_8h_source.html)
-
-### Deep Sleep API
+### `Sleep Manager` API
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.6/api/mbed__sleep_8h_source.html)
+
+### `Deep Sleep Lock` API
+
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.6/api/DeepSleepLock_8h_source.html)
 
 ### Example
 

--- a/docs/refs/api/platform/sleep.md
+++ b/docs/refs/api/platform/sleep.md
@@ -52,6 +52,10 @@ These Mbed OS drivers contain locking deep sleep:
 - `CAN`
 - `SerialBase`
 
+### API
+
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.6/api/DeepSleepLock_8h_source.html)
+
 ### Example
 
 This example shows SPI asynchronous transfer with deep sleep locking.

--- a/docs/refs/api/platform/sleep.md
+++ b/docs/refs/api/platform/sleep.md
@@ -52,9 +52,13 @@ These Mbed OS drivers contain locking deep sleep:
 - `CAN`
 - `SerialBase`
 
-### API
+### Sleep API
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.6/api/DeepSleepLock_8h_source.html)
+
+### Deep Sleep API
+
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.6/api/mbed__sleep_8h_source.html)
 
 ### Example
 


### PR DESCRIPTION
- sleep API
- sleep manager (new in mbed OS 5.6)

This depends on https://github.com/ARMmbed/mbed-os/pull/4912 , as this one gets to 5.6, this should be part of 5.6 documentation. I noticed all PR are to the new_engine branch, this also then.

The aim is to describe how sleep API should work, new API for sleep manager API (use `DeepSleepLock` class in applications). 

An example there was inspired based on SPI changes we did, we can either point directly to the file, or keep this, or any other suggestions?