### PR TITLE
Update Sonar example text

### DIFF
--- a/docs/reference/api/platform/Callback.md
+++ b/docs/reference/api/platform/Callback.md
@@ -19,6 +19,6 @@ The Callback API provides a convenient way to pass arguments to spawned threads.
 
 ### Sonar example
 
-Here is an example that uses everything discussed in the form of a minimal Sonar class.
+Here is an example that uses everything discussed in the [introduction to callbacks](/docs/v5.6/reference/platform-overview.html#callbacks) document in the form of a minimal Sonar class.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/callback-sonar-example/)](https://os.mbed.com/teams/mbed_example/code/callback-sonar-example/file/1713cdc51510/main.cpp)


### PR DESCRIPTION
Update the brief example explanation text for the Sonar example to reference the introduction to callback docs page rather than saying "...uses everything discussed..." which was a hold over from when it was written as one document.

@AnotherButler 