### PR TITLE
Add API specification for RawSerial class

### DIFF
--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,1 +1,34 @@
 ## RawSerial
+
+The RawSerial interface provides UART functionality without the use of streams like the Serial class. This makes it suitable for use in interrupt handlers with the RTOS.
+
+### RawSerial class reference
+
+[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/classmbed_1_1_raw_serial.html)
+
+<span class="notes">**Note**: On a Windows machine, you will need to install a USB serial driver. See [Windows serial configuration](/docs/v5.6/tutorials/serial-communication.html#windows-serial-driver).</span>
+
+Serial channels have a number of configurable parameters:
+
+  - _Baud Rate_ - There are a number of standard baud rates ranging from a few hundred bits per second, to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud.
+  - _Data length_ - Data transferred can be either 7 or 8 bits long. The default setting for a serial connection on the Mbed microcontroller is 8 bits.
+  - _Parity_ - You can add an optional parity bit. The parity bit will be automatically set to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.
+  - _Stop Bits_ - After data and parity bits have been transmitted, one or two stop bits are inserted to "frame" the data. The default setting for a serial connection on the Mbed microcontroller is one stop bit.
+
+The default settings for the Mbed microcontroller are described as _9600-8-N-1_, a  common notation for serial port settings.
+
+### RawSerial hello, world
+
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/RawSerial_HelloWorld/)](https://os.mbed.com/teams/mbed_example/code/RawSerial_HelloWorld/file/112a40a5991a/main.cpp)
+
+### RawSerial examples
+
+#### Example one
+
+Write a message to a device at a baud rate of 19200.
+
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_1/)](https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_1/file/6a0d9cb21969/main.cpp)
+
+#### Mbed OS Example
+
+RawSerial is commonly used in IRQ heavy UART operations such as the [ATParser](https://github.com/ARMmbed/ATParser/blob/3209400df676cbf0183a5894f648c71727602d30/BufferedSerial/BufferedSerial.cpp#L29) used in the ESP8266 driver. This driver uses UART on user supplied pins to communicate with the offchip ESP8266 module.

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -2,8 +2,12 @@
 
 The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md) print and scan functions the way the Serial class does. RawSerial does not retarget the standard library print and scan functions. Instead, RawSerial reimplements the print and scan functions to use each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes RawSerial suitable for use in interrupt handlers with the RTOS.
 
-Serial channels have the following configurable parameters:
+Serial channels have the following configurable parameters in the constructor:
+  - _Tx and Rx Pin_ - The physical serial transmit and receive pins. You can specify a Tx or Tx pin as Not Connected (NC) to get Simplex communication, or specify both to get full duplex.
+  - _Baud Rate_ - This setting is an optional constructor parameter. Standard baud rates range from a few hundred bits per second to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud. This setting may also be configured at run time.
 
+
+The following parameters can be configured at runtime in the RawSerial object. You can view more information about the configurable settings and functions in the class reference.
   - _Baud Rate_ - Standard baud rates range from a few hundred bits per second to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud.
   - _Data length_ - Transferred data can be either 7 or 8 bits long. The default setting for a serial connection on the Mbed microcontroller is 8 bits.
   - _Parity_ - You can add an optional parity bit. The object automatically sets the parity bit to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,6 +1,6 @@
 ## RawSerial
 
-The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md)  print and scan functions as is done in the Serial class. RawSerial does not retarget the standard library print and scan functions, but re-implements them to work using each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes it suitable for use in interrupt handlers with the RTOS.
+The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md) print and scan functions the way the Serial class does. RawSerial does not retarget the standard library print and scan functions. Instead, RawSerial reimplements the print and scan functions to use each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes RawSerial suitable for use in interrupt handlers with the RTOS.
 
 Serial channels have the following configurable parameters:
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,6 +1,6 @@
 ## RawSerial
 
-The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md)  print and scan functions as in the Serial class. Instead of using the standard library print and scan functions they are re-implemented to work using each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes it suitable for use in interrupt handlers with the RTOS.
+The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md)  print and scan functions as is done in the Serial class. RawSerial does not retarget the standard library print and scan functions, but re-implements them to work using each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes it suitable for use in interrupt handlers with the RTOS.
 
 Serial channels have the following configurable parameters:
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,6 +1,6 @@
 ## RawSerial
 
-The RawSerial class provides UART functionality without the use of [Stream's](https://os.mbed.com/docs/v5.6/reference/serial.html)  print and scan functions as in the Serial class. Instead of using the standard library print and scan functions they are re-implemented to work using each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes it suitable for use in interrupt handlers with the RTOS.
+The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md)  print and scan functions as in the Serial class. Instead of using the standard library print and scan functions they are re-implemented to work using each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes it suitable for use in interrupt handlers with the RTOS.
 
 Serial channels have the following configurable parameters:
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,13 +1,14 @@
 ## RawSerial
 
-The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md) print and scan functions the way the Serial class does. RawSerial does not retarget the standard library print and scan functions. Instead, RawSerial reimplements the print and scan functions to use each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes RawSerial suitable for use in interrupt handlers with the RTOS.
+The RawSerial class provides UART functionality without the use of [Stream's](https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/platform/Stream.md) print and scan functions the way the Serial class does. RawSerial does not retarget the standard library print and scan functions. Instead, RawSerial reimplements the print and scan functions to use each target's underlying serial communication functions. See the porting guide for [target serial support](/docs/v5.6/reference/contributing-target.html#serial). This makes RawSerial suitable for use in interrupt handlers with the RTOS.
 
 Serial channels have the following configurable parameters in the constructor:
+
   - _Tx and Rx Pin_ - The physical serial transmit and receive pins. You can specify a Tx or Tx pin as Not Connected (NC) to get Simplex communication, or specify both to get full duplex.
   - _Baud Rate_ - This setting is an optional constructor parameter. Standard baud rates range from a few hundred bits per second to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud. This setting may also be configured at run time.
 
-
 The following parameters can be configured at runtime in the RawSerial object. You can view more information about the configurable settings and functions in the class reference.
+
   - _Baud Rate_ - Standard baud rates range from a few hundred bits per second to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud.
   - _Data length_ - Transferred data can be either 7 or 8 bits long. The default setting for a serial connection on the Mbed microcontroller is 8 bits.
   - _Parity_ - You can add an optional parity bit. The object automatically sets the parity bit to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,6 +1,6 @@
 ## RawSerial
 
-The RawSerial interface provides UART functionality without the use of streams like the Serial class. This makes it suitable for use in interrupt handlers with the RTOS.
+The RawSerial class provides UART functionality without the use of streams like the Serial class. This makes it suitable for use in interrupt handlers with the RTOS.
 
 Serial channels have the following configurable parameters:
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -6,8 +6,8 @@ Serial channels have the following configurable parameters:
 
   - _Baud Rate_ - Standard baud rates range from a few hundred bits per second to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud.
   - _Data length_ - Transferred data can be either 7 or 8 bits long. The default setting for a serial connection on the Mbed microcontroller is 8 bits.
-  - _Parity_ - You can add an optional parity bit. The parity bit will be automatically set to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.
-  - _Stop Bits_ - After data and parity bits have been transmitted, one or two stop bits are inserted to "frame" the data. The default setting for a serial connection on the Mbed microcontroller is one stop bit.
+  - _Parity_ - You can add an optional parity bit. The object automatically sets the parity bit to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.
+  - _Stop Bits_ - After the transmission of data and parity bits, the RawSerial object inserts one or two stop bits to "frame" the data. The default setting for a serial connection on the Mbed microcontroller is one stop bit.
 
 _9600-8-N-1_, a  common notation for serial port settings, describes the default settings for the Mbed microcontroller.
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -1,6 +1,6 @@
 ## RawSerial
 
-The RawSerial class provides UART functionality without the use of streams like the Serial class. This makes it suitable for use in interrupt handlers with the RTOS.
+The RawSerial class provides UART functionality without the use of [Stream's](https://os.mbed.com/docs/v5.6/reference/serial.html)  print and scan functions as in the Serial class. Instead of using the standard library print and scan functions they are re-implemented to work using each target's underlying serial communication functions. See the porting guide for [target serial support](https://os.mbed.com/docs/v5.6/reference/contributing-target.html#serial). This makes it suitable for use in interrupt handlers with the RTOS.
 
 Serial channels have the following configurable parameters:
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -2,20 +2,20 @@
 
 The RawSerial interface provides UART functionality without the use of streams like the Serial class. This makes it suitable for use in interrupt handlers with the RTOS.
 
+Serial channels have the following configurable parameters:
+
+  - _Baud Rate_ - Standard baud rates range from a few hundred bits per second to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud.
+  - _Data length_ - Transferred data can be either 7 or 8 bits long. The default setting for a serial connection on the Mbed microcontroller is 8 bits.
+  - _Parity_ - You can add an optional parity bit. The parity bit will be automatically set to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.
+  - _Stop Bits_ - After data and parity bits have been transmitted, one or two stop bits are inserted to "frame" the data. The default setting for a serial connection on the Mbed microcontroller is one stop bit.
+
+_9600-8-N-1_, a  common notation for serial port settings, describes the default settings for the Mbed microcontroller.
+
 ### RawSerial class reference
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/classmbed_1_1_raw_serial.html)
 
-<span class="notes">**Note**: On a Windows machine, you will need to install a USB serial driver. See [Windows serial configuration](/docs/v5.6/tutorials/serial-communication.html#windows-serial-driver).</span>
-
-Serial channels have a number of configurable parameters:
-
-  - _Baud Rate_ - There are a number of standard baud rates ranging from a few hundred bits per second, to megabits per second. The default setting for a serial connection on the Mbed microcontroller is 9600 baud.
-  - _Data length_ - Data transferred can be either 7 or 8 bits long. The default setting for a serial connection on the Mbed microcontroller is 8 bits.
-  - _Parity_ - You can add an optional parity bit. The parity bit will be automatically set to make the number of 1s in the data either odd or even. Parity settings are *Odd*, *Even* or *None*. The default setting for a serial connection on the Arm Mbed microcontroller is None.
-  - _Stop Bits_ - After data and parity bits have been transmitted, one or two stop bits are inserted to "frame" the data. The default setting for a serial connection on the Mbed microcontroller is one stop bit.
-
-The default settings for the Mbed microcontroller are described as _9600-8-N-1_, a  common notation for serial port settings.
+<span class="notes">**Note**: On a Windows machine, you need to install a USB serial driver. See [Windows serial configuration](/docs/v5.6/tutorials/serial-communication.html#windows-serial-driver).</span>
 
 ### RawSerial hello, world
 
@@ -29,6 +29,6 @@ Write a message to a device at a baud rate of 19200.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_1/)](https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_1/file/6a0d9cb21969/main.cpp)
 
-#### Mbed OS Example
+#### Mbed OS example
 
-RawSerial is commonly used in IRQ heavy UART operations such as the [ATParser](https://github.com/ARMmbed/ATParser/blob/3209400df676cbf0183a5894f648c71727602d30/BufferedSerial/BufferedSerial.cpp#L29) used in the ESP8266 driver. This driver uses UART on user supplied pins to communicate with the offchip ESP8266 module.
+Common use cases for RawSerial are IRQ heavy UART operations, such as the [ATParser](https://github.com/ARMmbed/ATParser/blob/3209400df676cbf0183a5894f648c71727602d30/BufferedSerial/BufferedSerial.cpp#L29) in the ESP8266 driver. This driver uses UART on user supplied pins to communicate with the offchip ESP8266 module.


### PR DESCRIPTION
I didn't want to pull over and copy all of the Serial examples as that wouldn't add much. Tried to show examples closer to the use case of RawSerial, let me know if you think it's not sufficient or should be changed to something else.

@AnotherButler 
@sg- 