### PR TITLE
Remove build_script.md

### DIFF
--- a/docs/tools/debug/build_script.md
+++ b/docs/tools/debug/build_script.md
@@ -1,3 +1,0 @@
-## The Build Script Environment
-
-[https://github.com/ARMmbed/Handbook/blob/5.5/docs/advanced/build_script.md needs to be rewritten - it wasn't published because it's SDK stuff]


### PR DESCRIPTION
bulid_script.md was in the wrong place, and none of the contents could have gone
here. All of the information contained in this file is either so out of date
that it's no longer relevant, or are contained in other files. Most of this
information was made irrelevant by the introduction of Mbed CLI.