### PR TITLE
Add Chaining block device api docs

### DIFF
--- a/docs/reference/api/storage/ChainingBlockDevice.md
+++ b/docs/reference/api/storage/ChainingBlockDevice.md
@@ -1,6 +1,10 @@
 ## ChainingBlockDevice
 
-[Add description here.]
+The ChainingBlockDevice class provides a way to chain together multiple block devices. The chained block devices can then be interacted with as if they were a single block device of size equal to the sum of each sub storage unit. 
+
+Note that each block device's block size must be a multiple of the other devices' block sizes (512, 1024, etc).
+
+The constructor takes in an array of block device pointers and provides an object from which the grouped block devices can be accessed from as a single device.
 
 ### ChainingBlockDevice class reference
 
@@ -8,4 +12,10 @@
 
 ### ChainingBlockDevice example
 
-[Add example here.]
+ChainingBlockDevice example to create a FAT filesystem across multiple [HeapBlockDevices](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_heap_block_device.html).
+
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_1/)](https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_1/file/8ad9777787ba/main.cpp)
+
+ChainingBlockDevice example showing how to program and readback data off of a chained group of [HeapBlockDevices](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_heap_block_device.html).
+
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_2/)](https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_2/file/70419b9d778a/main.cpp)

--- a/docs/reference/api/storage/ChainingBlockDevice.md
+++ b/docs/reference/api/storage/ChainingBlockDevice.md
@@ -1,10 +1,10 @@
 ## ChainingBlockDevice
 
-The ChainingBlockDevice class provides a way to chain together multiple block devices. The chained block devices can then be interacted with as if they were a single block device of size equal to the sum of each sub storage unit. 
+The ChainingBlockDevice class provides a way to chain together multiple block devices. You can then interact with the chained block devices as if they were a single block device of size equal to the sum of each substorage unit. 
 
-Note that each block device's block size must be a multiple of the other devices' block sizes (512, 1024, etc).
+Note that each block device's block size must be a multiple of the other devices' block sizes (512, 1024 and so on).
 
-The constructor takes in an array of block device pointers and provides an object from which the grouped block devices can be accessed from as a single device.
+The constructor takes in an array of block device pointers and provides an object from which you can access the grouped block devices as a single device.
 
 ### ChainingBlockDevice class reference
 
@@ -12,10 +12,10 @@ The constructor takes in an array of block device pointers and provides an objec
 
 ### ChainingBlockDevice example
 
-ChainingBlockDevice example to create a FAT filesystem across multiple [HeapBlockDevices](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_heap_block_device.html).
+This ChainingBlockDevice example creates a FAT file system across multiple [HeapBlockDevices](/docs/v5.6/reference/heapblockdevice.html).
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_1/)](https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_1/file/8ad9777787ba/main.cpp)
 
-ChainingBlockDevice example showing how to program and readback data off of a chained group of [HeapBlockDevices](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_heap_block_device.html).
+This ChainingBlockDevice example shows how to program and read back data from a chained group of [HeapBlockDevices](/docs/v5.6/reference/heapblockdevice.html).
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_2/)](https://os.mbed.com/teams/mbed_example/code/ChainingBlockDevice_ex_2/file/70419b9d778a/main.cpp)


### PR DESCRIPTION
@AnotherButler I put in a link to the HeapBlockDevice class reference page for now as a cross reference. Let me know if you'd like different links.
@sg- 
