### PR TITLE
Move `device_has` docs into targets.json docs

### DIFF
--- a/docs/reference/contributing/target/exporter.md
+++ b/docs/reference/contributing/target/exporter.md
@@ -20,10 +20,10 @@ You can open the generated `.creator` project in Qt Creator, enabling integratio
 
 ##### CMSIS Packs
 
-uVision and IAR both use [CMSIS packs](http://www.keil.com/pack/doc/CMSIS/Pack/html/index.html) to find target information necessary to create a valid project file. Add a `device_name` attribute to your target as described in [Adding and Configuring Targets](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html) to support these exporters.
+uVision and IAR both use <a href="http://www.keil.com/pack/doc/CMSIS/Pack/html/index.html" target="_blank">CMSIS packs</a> to find target information necessary to create a valid project file. Add a `"device_name"` attribute to your target as <a href="https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html" target="_blank">Adding and configuring targets</a> describes to support these exporters.
 
 ##### uVision
-[`tools/export/uvision/uvision.tmpl`](https://github.com/ARMmbed/mbed-os/blob/master/tools/export/uvision/uvision.tmpl#L15) uses target information from CMSIS PACKs to generate valid uVision5 projects. If the program cannot find the device name, we use a generic Arm CPU target in uVision5.
+<a href=""https://github.com/ARMmbed/mbed-os/blob/master/tools/export/uvision/uvision.tmpl#L15" target="_blank">uVision project file template</a> uses target information from CMSIS Packs to generate valid uVision5 projects. If the uVision exporter cannot find the `"device_name"`, it substitutes a generic Arm CPU target.
 
 ##### IAR
 

--- a/docs/reference/contributing/target/exporter.md
+++ b/docs/reference/contributing/target/exporter.md
@@ -20,33 +20,10 @@ You can open the generated `.creator` project in Qt Creator, enabling integratio
 
 ##### CMSIS Packs
 
-uVision and IAR both use <a href="http://www.keil.com/pack/doc/CMSIS/Pack/html/index.html" target="_blank">CMSIS packs</a> to find target information necessary to create a valid project file.
-
-We use the tool <a href="https://github.com/ARMmbed/mbed-os/tree/master/tools/arm_pack_manager" target="_blank">ArmPackManager</a> to scrape <a href="https://www.keil.com/dd2/Pack/" target="_blank">MDK5 Software Packs</a> for target information by parsing <a href="http://sadevicepacksprod.blob.core.windows.net/idxfile/index.idx" target="_blank">http://www.keil.com/pack/index.idx</a>. <a href="https://github.com/ARMmbed/mbed-os/blob/master/tools/arm_pack_manager/index.json" target="_blank">index.json</a> stores the relevant information from the <a href="http://www.keil.com/pack/doc/CMSIS/Pack/html/" target="_blank">PDSC (Pack Description)</a> retrieved from each CMSIS PACK described in the index.
-
-A device support`.pdsc` file typically describes a family of devices. A <a href="/docs/v5.6/reference/contributing-target.html" target="_blank">device name</a> uniquely identifies each device. This name makes a natural key to associate a device with its information in `index.json`. To support IAR and uVision exports for your target, you must add a device name field in `targets.json` containing this key.
-
-<a href="http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc" target="_blank">http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc</a> is the PDSC that contains TEENSY_31 device (MK20DX256xxx7). ArmPackManager has parsed it, and `index.json` stores it. The device information begins on line 156:
-
-```xml
-      <device Dname="MK20DX256xxx7">
-        <processor Dfpu="0" Dmpu="0" Dendian="Little-endian" Dclock="72000000"/>
-        <compile header="Device\Include\MK20D7.h"  define="MK20DX256xxx7"/>
-        <debug      svd="SVD\MK20D7.svd"/>
-        <memory     id="IROM1"                      start="0x00000000"  size="0x40000"    startup="1"   default="1"/>
-        <memory     id="IROM2"                      start="0x10000000"  size="0x8000"     startup="0"   default="0"/>
-        <memory     id="IRAM1"                      start="0x20000000"  size="0x8000"     init   ="0"   default="1"/>
-        <memory     id="IRAM2"                      start="0x1FFF8000"  size="0x8000"     init   ="0"   default="0"/>
-        <algorithm  name="Flash\MK_P256.FLM"        start="0x00000000"  size="0x40000"                  default="1"/>
-        <algorithm  name="Flash\MK_D32_72MHZ.FLM"   start="0x10000000"  size="0x8000"                   default="1"/>
-        <book name="Documents\K20P100M72SF1RM.pdf"         title="MK20DX256xxx7 Reference Manual"/>
-        <book name="Documents\K20P100M72SF1.pdf"           title="MK20DX256xxx7 Data Sheet"/>
-      </device>
-```
+uVision and IAR both use [CMSIS packs](http://www.keil.com/pack/doc/CMSIS/Pack/html/index.html) to find target information necessary to create a valid project file. Add a `device_name` attribute to your target as described in [Adding and Configuring Targets](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html) to support these exporters.
 
 ##### uVision
-
-The `dname` (device name) field on line 156 directly corresponds to that in the uVision5 IDE Target Selection window. <a href="https://github.com/ARMmbed/mbed-os/blob/master/tools/export/uvision/uvision.tmpl#L15" target="_blank">`tools/export/uvision/uvision.tmpl`</a> uses target information from these packs to generate valid uVision5 projects. If the program cannot find the device name, we use a generic Arm CPU target in uVision5.
+[`tools/export/uvision/uvision.tmpl`](https://github.com/ARMmbed/mbed-os/blob/master/tools/export/uvision/uvision.tmpl#L15) uses target information from CMSIS PACKs to generate valid uVision5 projects. If the program cannot find the device name, we use a generic Arm CPU target in uVision5.
 
 ##### IAR
 

--- a/docs/reference/contributing/target/flash.md
+++ b/docs/reference/contributing/target/flash.md
@@ -1,10 +1,10 @@
-### Flash and Bootloader
+### Flash and bootloader
 
 Update target to support bootloader:
 
 1. Update linker script.
-1. Add required metadata to targets.json
-1. Implement `mbed_start_application`
+1. Add required metadata to `targets.json`.
+1. Implement `mbed_start_application`.
 1. Implement flash HAL API.
 1. Verify changes with tests.
 
@@ -59,9 +59,9 @@ Bootloader-ready declaration of flash VTOR address:
 #endif
 ```
 
-#### Targets.json Metadata
+#### `targets.json` metadata
 
-The managed and un-managed bootloader builds require some target metadata from CMSIS PACKs. Add a `device_name` attribute to your target as described in [Adding and Configuring Targets](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html).
+The managed and unmanaged bootloader builds require some target metadata from CMSIS Packs. Add a `"device_name"` attribute to your target as <a href="https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html" target="_blank">Adding and configuring targets</a> describes.
 
 #### Start application
 

--- a/docs/reference/contributing/target/flash.md
+++ b/docs/reference/contributing/target/flash.md
@@ -1,8 +1,10 @@
-### Flash
+### Flash and Bootloader
 
-Update target to support bootloader.
+Update target to support bootloader:
 
 1. Update linker script.
+1. Add required metadata to targets.json
+1. Implement `mbed_start_application`
 1. Implement flash HAL API.
 1. Verify changes with tests.
 
@@ -56,6 +58,10 @@ Bootloader-ready declaration of flash VTOR address:
     #error "Flash vector address not set for this toolchain"
 #endif
 ```
+
+#### Targets.json Metadata
+
+The managed and un-managed bootloader builds require some target metadata from CMSIS PACKs. Add a `device_name` attribute to your target as described in [Adding and Configuring Targets](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html).
 
 #### Start application
 

--- a/docs/reference/contributing/target/target.md
+++ b/docs/reference/contributing/target/target.md
@@ -19,7 +19,7 @@ cd ..
 
 #### Target description
 
-Add the target description to `mbed-os\targets\targets.json`:
+Add the target description to `mbed-os\targets\targets.json` using keys described in the [adding and configuring targets section](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html). We recommend that you run the [targets lint script](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html#style-guide) on your target hierarchy before submitting your pull request:
 
 ``` json
 "MCU_NAME": {

--- a/docs/reference/contributing/target/target.md
+++ b/docs/reference/contributing/target/target.md
@@ -19,7 +19,7 @@ cd ..
 
 #### Target description
 
-Add the target description to `mbed-os\targets\targets.json` using keys described in the [adding and configuring targets section](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html). We recommend that you run the [targets lint script](https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html#style-guide) on your target hierarchy before submitting your pull request:
+Add the target description to `mbed-os\targets\targets.json` using keys that the <a href="https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html" target="_blank">Adding and configuring targets section</a> describes. We recommend that you run the <a href="https://os.mbed.com/docs/v5.6/tools/adding-and-configuring-targets.html#style-guide">targets lint script</a> on your target hierarchy before submitting your pull request:
 
 ``` json
 "MCU_NAME": {

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -197,7 +197,7 @@ Use this property to pass necessary data for exporting to various third party to
 
 We use the tool <a href="https://github.com/ARMmbed/mbed-os/tree/master/tools/arm_pack_manager" target="_blank">ArmPackManager</a> to parse CMSIS Packs for target information. <a href="https://github.com/ARMmbed/mbed-os/blob/master/tools/arm_pack_manager/index.json" target="_blank">`index.json`</a> stores the parsed information from the <a href="http://www.keil.com/pack/doc/CMSIS/Pack/html/" target="_blank">PDSC (Pack Description</a> retrieved from each CMSIS Pack.
 
-The <a href="/docs/v5.6/reference/contributing-target.html">`"device_name"`</a> attribute it `targets.json` maps from a target in Mbed OS to a device in a CMSIS Pack. To support IAR and uVision exports for your target, You must add a `"device_name"` field in `targets.json` containing this key.
+The <a href="/docs/v5.6/reference/contributing-target.html">`"device_name"`</a> attribute it `targets.json` maps from a target in Mbed OS to a device in a CMSIS Pack. To support IAR and uVision exports for your target, you must add a `"device_name"` field in `targets.json` containing this key.
 
 <a href="http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc" target="_blank">http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc</a> is the PDSC that contains TEENSY_31 device (MK20DX256xxx7). ArmPackManager has parsed this PDSC, and `index.json` stores the device information. The device information begins on line 156 of the `.pdsc` file:
 

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -195,11 +195,11 @@ The `post_build_hook` for the `TEENSY3_1` converts the output file (`binf`) from
 
 Use this property to pass necessary data for exporting to various third party tools and IDEs and for building applications with bootloaders.
 
-We use the tool [ArmPackManager](https://github.com/ARMmbed/mbed-os/tree/master/tools/arm_pack_manager) to scrape [MDK5 Software Packs](https://www.keil.com/dd2/Pack/) for target information by parsing [http://www.keil.com/pack/index.idx](http://sadevicepacksprod.blob.core.windows.net/idxfile/index.idx). [index.json](https://github.com/ARMmbed/mbed-os/blob/master/tools/arm_pack_manager/index.json) stores the relevant information from the [PDSC (Pack Description)](http://www.keil.com/pack/doc/CMSIS/Pack/html/) retrieved from each CMSIS PACK described in the index.
+We use the tool <a href="https://github.com/ARMmbed/mbed-os/tree/master/tools/arm_pack_manager" target="_blank">ArmPackManager</a> to parse CMSIS Packs for target information. <a href="https://github.com/ARMmbed/mbed-os/blob/master/tools/arm_pack_manager/index.json" target="_blank">`index.json`</a> stores the parsed information from the <a href="http://www.keil.com/pack/doc/CMSIS/Pack/html/" target="_blank">PDSC (Pack Description</a> retrieved from each CMSIS Pack.
 
-A device support`.pdsc` file typically describes a family of devices. Each device is uniquely identified by its [device name](/docs/v5.6/reference/contributing-target.html). This name makes a natural key to associate a device with its information in `index.json`. To support IAR and uVision exports for your target, You must add a [device_name](/docs/v5.6/reference/contributing-target.html) field in `targets.json` containing this key.
+The <a href="/docs/v5.6/reference/contributing-target.html">`"device_name"`</a> attribute it `targets.json` maps from a target in Mbed OS to a device in a CMSIS Pack. To support IAR and uVision exports for your target, You must add a `"device_name"` field in `targets.json` containing this key.
 
-[http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc](http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc) is the PDSC that contains TEENSY_31 device (MK20DX256xxx7). ArmPackManager has parsed it, and `index.json` stores it. The device information begins on line 156:
+<a href="http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc" target="_blank">http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc</a> is the PDSC that contains TEENSY_31 device (MK20DX256xxx7). ArmPackManager has parsed this PDSC, and `index.json` stores the device information. The device information begins on line 156 of the `.pdsc` file:
 
 ```xml
 <device Dname="MK20DX256xxx7">

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -195,7 +195,29 @@ The `post_build_hook` for the `TEENSY3_1` converts the output file (`binf`) from
 
 Use this property to pass necessary data for exporting to various third party tools and IDEs and for building applications with bootloaders.
 
-Please see <a href="/docs/v5.6/tools/exporting.html" target="_blank">our exporting page</a> for information about this field.
+We use the tool [ArmPackManager](https://github.com/ARMmbed/mbed-os/tree/master/tools/arm_pack_manager) to scrape [MDK5 Software Packs](https://www.keil.com/dd2/Pack/) for target information by parsing [http://www.keil.com/pack/index.idx](http://sadevicepacksprod.blob.core.windows.net/idxfile/index.idx). [index.json](https://github.com/ARMmbed/mbed-os/blob/master/tools/arm_pack_manager/index.json) stores the relevant information from the [PDSC (Pack Description)](http://www.keil.com/pack/doc/CMSIS/Pack/html/) retrieved from each CMSIS PACK described in the index.
+
+A device support`.pdsc` file typically describes a family of devices. Each device is uniquely identified by its [device name](/docs/v5.6/reference/contributing-target.html). This name makes a natural key to associate a device with its information in `index.json`. To support IAR and uVision exports for your target, You must add a [device_name](/docs/v5.6/reference/contributing-target.html) field in `targets.json` containing this key.
+
+[http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc](http://www.keil.com/pack/Keil.Kinetis_K20_DFP.pdsc) is the PDSC that contains TEENSY_31 device (MK20DX256xxx7). ArmPackManager has parsed it, and `index.json` stores it. The device information begins on line 156:
+
+```xml
+<device Dname="MK20DX256xxx7">
+  <processor Dfpu="0" Dmpu="0" Dendian="Little-endian" Dclock="72000000"/>
+  <compile header="Device\Include\MK20D7.h"  define="MK20DX256xxx7"/>
+  <debug      svd="SVD\MK20D7.svd"/>
+  <memory     id="IROM1"                      start="0x00000000"  size="0x40000"    startup="1"   default="1"/>
+  <memory     id="IROM2"                      start="0x10000000"  size="0x8000"     startup="0"   default="0"/>
+  <memory     id="IRAM1"                      start="0x20000000"  size="0x8000"     init   ="0"   default="1"/>
+  <memory     id="IRAM2"                      start="0x1FFF8000"  size="0x8000"     init   ="0"   default="0"/>
+  <algorithm  name="Flash\MK_P256.FLM"        start="0x00000000"  size="0x40000"                  default="1"/>
+  <algorithm  name="Flash\MK_D32_72MHZ.FLM"   start="0x10000000"  size="0x8000"                   default="1"/>
+  <book name="Documents\K20P100M72SF1RM.pdf"         title="MK20DX256xxx7 Reference Manual"/>
+  <book name="Documents\K20P100M72SF1.pdf"           title="MK20DX256xxx7 Data Sheet"/>
+</device>
+```
+
+The `device_name` key in `targets.json` is `MK20DX256xxx7` for any target that uses this particular MCU.
 
 #### `OUTPUT_EXT`
 

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -93,7 +93,7 @@ If `public` is not defined for a target, it defaults to `true`.
 
 <span class="notes">**Note:** Unlike other target properties, **the value of `public` is not inherited from a parent to its children**.</span>
 
-### `macros`, `macros_add` and `macros_remove`
+#### `macros`, `macros_add` and `macros_remove`
 
 The `macros` property defines a list of macros that are available when compiling code. You may define these macros with or without a value. For example, the declaration `"macros": ["NO_VALUE", "VALUE=10"]` will add `-DNO_VALUE -DVALUE=10` to the compiler's command-line.
 


### PR DESCRIPTION
Link to this document from all of the places that used to incorrectly link
to the exporters documentation

I also notice someone changed the links from markdown style to HTML
style since I last edited this document. I don't think this is a great
idea, but if you want me to recreate those changes on this branch, I can.

Resolves https://github.com/ARMmbed/mbed-os/issues/4057