### PR TITLE
Add prohibited word check Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,9 @@ jobs:
       script:
         # Run scripts to search for added prohibited words
         - python check_tools/validate.py -c -i check_tools/prohibited.txt -f . &> check_tools/pr_black_list.log
-        - git remote add upstream https://github.com/armmbed/Handbook.git
-        - git fetch --depth=1 upstream new_engine
-        - git checkout new_engine
+        - git remote add upstream https://github.com/armmbed/mbed-os-5-docs.git
+        - git fetch --depth=1 upstream development
+        - git checkout development
         - python check_tools/validate.py -c -i check_tools/prohibited.txt -f . &> check_tools/head_black_list.log
         - python check_tools/smartdiff.py
 # Manage statuses

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,16 @@ jobs:
                 fi
             fi
 
+      env:
+        - NAME=prohibited-word-check
+      script:
+        # Run scripts to search for added prohibited words
+        - python check_tools/validate.py -c -i check_tools/prohibited.txt -f . &> check_tools/pr_black_list.log
+        - git remote add upstream https://github.com/armmbed/Handbook.git
+        - git fetch --depth=1 upstream new_engine
+        - git checkout new_engine
+        - python check_tools/validate.py -c -i check_tools/prohibited.txt -f . &> check_tools/head_black_list.log
+        - python check_tools/smartdiff.py
 # Manage statuses
 before_install:
   - |
@@ -103,4 +113,3 @@ after_success:
 # Job control
 stages:
     - name: test
-

--- a/check_tools/smartdiff.py
+++ b/check_tools/smartdiff.py
@@ -23,25 +23,33 @@ def main():
 
     for doc,words in pr_dict.iteritems():
         # Split the line number and trailing newlines from the list of found prohibited words
-        # Check for move in file location as the path is included in the key. Catch on try failure
         try:
-            stripped_pr_words = [word.split(',')[1].replace("\n","") for word in words]
+            # The compact list mode of the validation script only lists files that contained prohibited
+            # words. If a key error is found here, the head revision contained no prohibited words. Fill
+            # with empty list to compare the PR revision against
             stripped_head_words = [word.split(',')[1].replace("\n","") for word in head_dict[doc]]
+        except KeyError:
+            stripped_head_words = []
+
+        try:
+            # Check for move in file location as the path is included in the key. Catch on try failure
+            stripped_pr_words = [word.split(',')[1].replace("\n","") for word in words]
+
+            # Do not want to trigger failure on removed prohibited words from existing docs.
+            # Subtracting the set of PR words from the head revision list works as this filter
+            diff = list(set(stripped_pr_words) - set(stripped_head_words))
+
+            if diff:
+                print "Found added words from the prohibited list in file %s..." % doc
+                result = -1
+                for word in diff:
+                    # Find word in unstripped set to pull in line number
+                    line = words[diff.index(word)].split(',')[0]
+                    print "\t- Line: %s, Word: %s" % (line, word)
+
         except KeyError as E:
             print "File name or location change, skipping file: %s" % E
-            result += 1
-
-        # Do not want to trigger failure on removed prohibited words from existing docs.
-        # Subtracting the set of PR words from the head revision list works as this filter
-        diff = list(set(stripped_pr_words) - set(stripped_head_words))
-
-        if diff:
-            print "Found added words from the prohibited list in file %s..." % doc
-            result += 2
-            for word in diff:
-                # Find word in unstripped set to pull in line number
-                line = words[diff.index(word)].split(',')[0]
-                print "\t- Line: %s, Word: %s" % (line, word)
+            result = -1
 
     sys.exit(result)
 

--- a/check_tools/smartdiff.py
+++ b/check_tools/smartdiff.py
@@ -25,31 +25,26 @@ def main():
         # Split the line number and trailing newlines from the list of found prohibited words
         try:
             # The compact list mode of the validation script only lists files that contained prohibited
-            # words. If a key error is found here, the head revision contained no prohibited words. Fill
-            # with empty list to compare the PR revision against
+            # words. If a key error is found here, either the head revision contained no prohibited words, a
+            # new file was added, or an existing file was moved or renamed. Fill with empty list to
+            # compare the PR revision against
             stripped_head_words = [word.split(',')[1].replace("\n","") for word in head_dict[doc]]
         except KeyError:
             stripped_head_words = []
 
-        try:
-            # Check for move in file location as the path is included in the key. Catch on try failure
-            stripped_pr_words = [word.split(',')[1].replace("\n","") for word in words]
+        stripped_pr_words = [word.split(',')[1].replace("\n","") for word in words]
 
-            # Do not want to trigger failure on removed prohibited words from existing docs.
-            # Subtracting the set of PR words from the head revision list works as this filter
-            diff = list(set(stripped_pr_words) - set(stripped_head_words))
+        # Do not want to trigger failure on removed prohibited words from existing docs.
+        # Subtracting the set of PR words from the head revision list works as this filter
+        diff = list(set(stripped_pr_words) - set(stripped_head_words))
 
-            if diff:
-                print "Found added words from the prohibited list in file %s..." % doc
-                result = -1
-                for word in diff:
-                    # Find word in unstripped set to pull in line number
-                    line = words[diff.index(word)].split(',')[0]
-                    print "\t- Line: %s, Word: %s" % (line, word)
-
-        except KeyError as E:
-            print "File name or location change, skipping file: %s" % E
+        if diff:
+            print "Found added words from the prohibited list in file %s..." % doc
             result = -1
+            for word in diff:
+                # Find word in unstripped set to pull in line number
+                line = words[diff.index(word)].split(',')[0]
+                print "\t- Line: %s, Word: %s" % (line, word)
 
     sys.exit(result)
 

--- a/check_tools/smartdiff.py
+++ b/check_tools/smartdiff.py
@@ -13,8 +13,8 @@ def format_map(black_list):
     return _map
 
 def main():
-    pr_list   = open('pr_black_list.log', 'r').read()
-    head_list = open('head_black_list.log', 'r').read()
+    pr_list   = open('check_tools/pr_black_list.log', 'r').read()
+    head_list = open('check_tools/head_black_list.log', 'r').read()
 
     pr_dict   = format_map(pr_list)
     head_dict = format_map(head_list)

--- a/check_tools/smartdiff.py
+++ b/check_tools/smartdiff.py
@@ -1,0 +1,49 @@
+import sys
+
+def format_map(black_list):
+    docs  = black_list.split(':')[1::2]
+    words = black_list.split(':')[0::2][1:]
+
+    index = 0
+    _map = {}
+    for doc in docs:
+        _map[doc] = words[index].split(';')
+        index += 1
+
+    return _map
+
+def main():
+    pr_list   = open('pr_black_list.log', 'r').read()
+    head_list = open('head_black_list.log', 'r').read()
+
+    pr_dict   = format_map(pr_list)
+    head_dict = format_map(head_list)
+
+    result = 0
+
+    for doc,words in pr_dict.iteritems():
+        # Split the line number and trailing newlines from the list of found prohibited words
+        # Check for move in file location as the path is included in the key. Catch on try failure
+        try:
+            stripped_pr_words = [word.split(',')[1].replace("\n","") for word in words]
+            stripped_head_words = [word.split(',')[1].replace("\n","") for word in head_dict[doc]]
+        except KeyError as E:
+            print "File name or location change, skipping file: %s" % E
+            result += 1
+
+        # Do not want to trigger failure on removed prohibited words from existing docs.
+        # Subtracting the set of PR words from the head revision list works as this filter
+        diff = list(set(stripped_pr_words) - set(stripped_head_words))
+
+        if diff:
+            print "Found added words from the prohibited list in file %s..." % doc
+            result += 2
+            for word in diff:
+                # Find word in unstripped set to pull in line number
+                line = words[diff.index(word)].split(',')[0]
+                print "\t- Line: %s, Word: %s" % (line, word)
+
+    sys.exit(result)
+
+if __name__ == "__main__":
+    main()

--- a/check_tools/validate.py
+++ b/check_tools/validate.py
@@ -1,22 +1,33 @@
 import mmap
 import re
 import os
+import sys
 from optparse import OptionParser
 
 words = {}
 
-def validate_file(inputfilename):
+def validate_file(inputfilename, compact=False):
     global words
-    print "Validating file:%s"%inputfilename
+    
+    if not compact:
+        print "Validating file:%s"%inputfilename
     input_file = open(inputfilename)
     alllines = input_file.readlines()
     
     line=1
+    first = True
     for eachline in alllines:
         result = re.findall(words,eachline,flags=re.IGNORECASE)
         for eachresult in result:
             if eachresult!=None and len(eachresult)!=0:
-                print "\tLine %d:found \"%s\""%(line,str(eachresult))
+                if compact:
+                    if first:
+                        sys.stdout.write(":%s:%d,%s" % (inputfilename, line, str(eachresult)))
+                    else:
+                        sys.stdout.write(";%d,%s" % (line, str(eachresult)))
+                else:
+                    print "\tLine %d:found \"%s\"" % (line, str(eachresult))
+                first = False
         line=line+1            
 
 def main():
@@ -24,24 +35,26 @@ def main():
     parser = OptionParser()
     parser.add_option("-f", "--inputfile",  dest="inputfile",  action="store", type="string", default="" , help="File to be validated", metavar="FILE")
     parser.add_option("-i", "--wordsfile", dest="wordsfile", action="store", type="string", default="prohibited.txt", help="File containing the words to be checked", metavar="FILE")
+    parser.add_option("-c", "--compact", dest="compact", action="store_true", default=False, help="Format output text for human readability (verbose) or compact for scripting") 
+
     (options, args) = parser.parse_args()
-    
+
     if len(options.inputfile) <= 0 or len(options.wordsfile) == None:
         parser.error("Invalid arguments")
         
     words_file = open(options.wordsfile)
     alllines = words_file.read()
-    words = alllines[:-1].replace("\n","|")
-    
+    words = alllines[:-1].replace("\n","|")   
+ 
     if os.path.isfile(options.inputfile):
-        validate_file(options.inputfile)
+        validate_file(options.inputfile, options.compact)
         
     if(os.path.isdir(options.inputfile)):
         for root, dirs, files in os.walk(options.inputfile, topdown=False):
             for name in files:
                 file_to_validate=os.path.join(root, name)
                 if(file_to_validate.endswith(".md")):
-                    validate_file(os.path.join(root, name))  
+                    validate_file(os.path.join(root, name), options.compact)  
             #   print(os.path.join(root, name))
             #for name in dirs:
             #   print(os.path.join(root, name)) 


### PR DESCRIPTION
Covered this in the earlier email mostly, but recapping here for posterity. Spoke with Senthil and decided to put up the PR now, we can discuss it more when you're back in the office.

The job works by comparing the PR revision against the current head (set to new_engine) and listing any new prohibited words found. In the case of new, renamed, or moved files all prohibited words are listed from the file in question if present. The thought being a) It’s a bit difficult to differentiate between a new file and a renamed file from the context of the script (I could try to add in some git checks but it’ll be a bit uglier) and b) If you’re touching a file, might not be a bad thing to be aware of any black listed words present so we can slowly clean up the existing docs. Line and whitespace changes will not trigger errors, the word itself is mapped to its file and compared against the two revisions. Likewise removing existing prohibited words will not trigger errors.

Sample runs:

- Expected failures: https://github.com/kegilbert/Handbook/pull/2
- Expected pass:     https://github.com/kegilbert/Handbook/pull/3

Clicking on the failed Travis job in the PR will show you the build, scroll to the bottom to get a list of errors.

The concern was with fuzzy situations where a prohibited word pops up in a phrase where it’s deemed ok to have, or if you move a file and don’t want to fix all of the errors you’ll have a failing CI when merging. I think it'd be better to at least have the list of failed words on each PR and fail the CI on any errors and submit based on manual inspection.

Thoughts?

@AnotherButler 
@iriark01 