### PR TITLE
Correct importance of state code sample

### DIFF
--- a/docs/reference/api/platform/platform.md
+++ b/docs/reference/api/platform/platform.md
@@ -293,7 +293,7 @@ int main() {
     adc1.attach(low_pass_step, &low_pass_result1);
 
     // Register a second low pass filter, no more issues!
-    adc2.attach(low_pass_step, &low_pass_result1);
+    adc2.attach(low_pass_step, &low_pass_result2);
 }
 ```
 


### PR DESCRIPTION
Update code example to use correct variable. The sample before would store the state of two low pass filter results in one variable.
@kegilbert @geky 