### PR TITLE
Update Ticker and SleepManager based on feedback

### DIFF
--- a/docs/reference/api/drivers/Ticker.md
+++ b/docs/reference/api/drivers/Ticker.md
@@ -6,11 +6,11 @@ You can create any number of Ticker objects, allowing multiple outstanding inter
 
 ### Warnings and notes
 
-* Timers are based on 32-bit int microsecond counters, so they can only time up to a maximum of 2^31-1 microseconds (30 minutes). They are designed for times between microseconds and seconds. For longer times, you should consider the time() real time clock.
-
 * No blocking code in ISR: avoid any call to wait, infinite while loop or blocking calls in general.
 
 * No printf, malloc or new in ISR: avoid any call to bulky library functions. In particular, certain library functions (such as printf, malloc and new) are not re-entrant, and their behavior could be corrupted when called from an ISR.
+
+* While an event is attached to a Ticker deep sleep is blocked to maintain accurate timing. If you don't need microsecond precision consider using the LowPowerTicker class instead since this does not block deep sleep mode.
 
 ### Ticker class reference
 

--- a/docs/reference/api/drivers/Ticker.md
+++ b/docs/reference/api/drivers/Ticker.md
@@ -6,11 +6,11 @@ You can create any number of Ticker objects, allowing multiple outstanding inter
 
 ### Warnings and notes
 
-* No blocking code in ISR: avoid any call to wait, infinite while loop or blocking calls in general.
+- No blocking code in ISR: avoid any call to wait, infinite while loop or blocking calls in general.
 
-* No printf, malloc or new in ISR: avoid any call to bulky library functions. In particular, certain library functions (such as printf, malloc and new) are not re-entrant, and their behavior could be corrupted when called from an ISR.
+- No printf, malloc or new in ISR: avoid any call to bulky library functions. In particular, certain library functions (such as printf, malloc and new) are not re-entrant, and their behavior could be corrupted when called from an ISR.
 
-* While an event is attached to a Ticker deep sleep is blocked to maintain accurate timing. If you don't need microsecond precision consider using the LowPowerTicker class instead since this does not block deep sleep mode.
+- While an event is attached to a Ticker, deep sleep is blocked to maintain accurate timing. If you don't need microsecond precision, consider using the LowPowerTicker class instead because this does not block deep sleep mode.
 
 ### Ticker class reference
 

--- a/docs/reference/api/platform/SleepManager.md
+++ b/docs/reference/api/platform/SleepManager.md
@@ -22,7 +22,7 @@ void main()
 }
 ```
 
-Note: Mbed OS handles sleep for you automatically when you call any of the wait functions. You do not need to call `sleep()` directly unless you are overriding the default sleep handling of Mbed OS.
+<span class="notes">**Note:** Mbed OS handles sleep for you automatically when you call any of the wait functions. You do not need to call `sleep()` directly unless you are overriding the default sleep handling of Mbed OS.</span>
 
 ### Sleep modes
 

--- a/docs/reference/api/platform/SleepManager.md
+++ b/docs/reference/api/platform/SleepManager.md
@@ -22,6 +22,8 @@ void main()
 }
 ```
 
+Note: Mbed OS handles sleep for you automatically when you call any of the wait functions. You do not need to call `sleep()` directly unless you are overriding the default sleep handling of Mbed OS.
+
 ### Sleep modes
 
 There are two available sleep modes:
@@ -34,7 +36,7 @@ You can wake up the processor by any internal peripheral interrupt or external p
 
 2. Deep sleep mode
 
-This mode is similar to sleep but saves more power and has a longer wakeup time. It saves power by turning off the high-speed clocks. Because of this, you can only enter this mode when peripherals relying on high-speed clocks are not in use. Peripherals that do not rely on high-speed clocks include the lp ticker, RTC and external interrupt on a pin. This mode maintains all state.
+This mode is similar to sleep but saves more power and has a longer wakeup time. It saves power by turning off the high-speed clocks. Because of this, you can only enter this mode when peripherals relying on high-speed clocks are not in use. Peripherals that do not rely on high-speed clocks include the LowPowerTicker, RTC and InterruptIn APIs. This mode maintains all state.
 
 ### Sleep manager
 


### PR DESCRIPTION
Remove information about the 30-minute limitation from the Ticker docs, as the newer API is not limited by this. Add a note to about the higher power consumption of ticker. Add a note to SleepManager indicating that sleep() should not need to be called normally. Also explicitly reference classes which are safe to use in deep sleep mode.