### PR TITLE
Snippet workaround

### DIFF
--- a/docs/reference/api/connectivity/bluetooth/BatteryService.md
+++ b/docs/reference/api/connectivity/bluetooth/BatteryService.md
@@ -4,7 +4,7 @@
 
 ### BatteryService class reference
 
-[![View code](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_battery_service.html)
+[![View code](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_battery_service.html)
 
 ### BatteryService example
 

--- a/docs/reference/api/connectivity/bluetooth/EnvironmentalService.md
+++ b/docs/reference/api/connectivity/bluetooth/EnvironmentalService.md
@@ -4,7 +4,7 @@
 
 ### EnvironmentalService class reference
 
-[![View code](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_environmental_service.html)
+[![View code](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_environmental_service.html)
 
 ### EnvironmentalService example
 

--- a/docs/reference/api/connectivity/bluetooth/Gap.md
+++ b/docs/reference/api/connectivity/bluetooth/Gap.md
@@ -4,7 +4,7 @@
 
 ### Gap class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_gap.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_gap.html)
 
 ### Gap example
 

--- a/docs/reference/api/connectivity/bluetooth/GattClient.md
+++ b/docs/reference/api/connectivity/bluetooth/GattClient.md
@@ -4,7 +4,7 @@
 
 ### GattClient class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_gatt_client.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_gatt_client.html)
 
 ### GattClient example
 

--- a/docs/reference/api/connectivity/bluetooth/GattServer.md
+++ b/docs/reference/api/connectivity/bluetooth/GattServer.md
@@ -4,7 +4,7 @@
 
 ### GattServer class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_gatt_server.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_gatt_server.html)
 
 ### GattServer example
 

--- a/docs/reference/api/connectivity/bluetooth/UARTService.md
+++ b/docs/reference/api/connectivity/bluetooth/UARTService.md
@@ -4,7 +4,7 @@
 
 ### UARTService class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_u_a_r_t_service.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_u_a_r_t_service.html)
 
 ### UARTService example
 

--- a/docs/reference/api/connectivity/networksocket/CellularInterface.md
+++ b/docs/reference/api/connectivity/networksocket/CellularInterface.md
@@ -6,7 +6,7 @@ Arm Mbed OS provides a <a href="https://github.com/ARMmbed/mbed-os/tree/master/f
 
 ### CellularBase class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_cellular_base.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_cellular_base.html)
 
 ### Usage
 

--- a/docs/reference/api/connectivity/networksocket/EthInterface.md
+++ b/docs/reference/api/connectivity/networksocket/EthInterface.md
@@ -4,7 +4,7 @@ The EthInterface provides a C++ API for connecting to the internet over Ethernet
 
 ### EthInterface class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_eth_interface.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_eth_interface.html)
 
 ### Usage
 

--- a/docs/reference/api/connectivity/networksocket/SocketAddress.md
+++ b/docs/reference/api/connectivity/networksocket/SocketAddress.md
@@ -4,7 +4,7 @@ Use the SocketAddress class to represent the IP address and port pair of a uniqu
 
 ### SocketAddress class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_socket_address.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_socket_address.html)
 
 ### SocketAddress Example
 

--- a/docs/reference/api/connectivity/networksocket/TCPServer.md
+++ b/docs/reference/api/connectivity/networksocket/TCPServer.md
@@ -8,7 +8,7 @@ Refer to <a href="/docs/v5.7/reference/tcpsocket.html" target="_blank">TCPSocket
 
 ### TCPServer class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_t_c_p_server.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_t_c_p_server.html)
 
 ### TCPServer example
 

--- a/docs/reference/api/connectivity/networksocket/TCPSocket.md
+++ b/docs/reference/api/connectivity/networksocket/TCPSocket.md
@@ -8,7 +8,7 @@ Refer to <a href="/docs/v5.7/reference/tcpserver.html" target="_blank">TCPServer
 
 ### TCPSocket class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_t_c_p_socket.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_t_c_p_socket.html)
 
 ### TCPSocket Example
 

--- a/docs/reference/api/connectivity/networksocket/UDPSocket.md
+++ b/docs/reference/api/connectivity/networksocket/UDPSocket.md
@@ -6,7 +6,7 @@ The constructor takes in the NetworkStack pointer to open the socket on the spec
 
 ### UDPSocket class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_u_d_p_socket.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_u_d_p_socket.html)
 
 ### UDPSocket Example
 

--- a/docs/reference/api/connectivity/networksocket/WifiInterface.md
+++ b/docs/reference/api/connectivity/networksocket/WifiInterface.md
@@ -6,7 +6,7 @@ There are multiple <a href="https://os.mbed.com/components/cat/wifi/" target="_b
 
 ### Wi-Fi class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_wi_fi_interface.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_wi_fi_interface.html)
 
 ### Usage
 

--- a/docs/reference/api/drivers/AnalogIn.md
+++ b/docs/reference/api/drivers/AnalogIn.md
@@ -6,7 +6,7 @@ Use the AnalogIn API to read an external voltage applied to an analog input pin.
 
 ### AnalogIn class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_analog_in.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_analog_in.html)
 
 ### AnalogIn hello, world
 

--- a/docs/reference/api/drivers/AnalogOut.md
+++ b/docs/reference/api/drivers/AnalogOut.md
@@ -6,7 +6,7 @@ Use the AnalogOut interface to set the voltage of an analog output pin as a floa
 
 ### AnalogOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_analog_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_analog_out.html)
 
 ### AnalogOut hello, world
 

--- a/docs/reference/api/drivers/BusIn.md
+++ b/docs/reference/api/drivers/BusIn.md
@@ -10,7 +10,7 @@ You can use any of the numbered Arm Mbed pins as a DigitalIn in the BusIn.
 
 ### BusIn class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_bus_in.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_bus_in.html)
 
 ### BusIn Hello World!
 

--- a/docs/reference/api/drivers/BusInOut.md
+++ b/docs/reference/api/drivers/BusInOut.md
@@ -8,7 +8,7 @@ You can use any of the numbered Arm Mbed pins as a DigitalInOut.
 
 ### BusInOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_bus_in_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_bus_in_out.html)
 
 ### BusInOut Hello World!
 

--- a/docs/reference/api/drivers/BusOut.md
+++ b/docs/reference/api/drivers/BusOut.md
@@ -11,7 +11,7 @@ You can use any of the numbered Arm Mbed pins as a DigitalOut in the BusOut.
 
 ### BusOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_bus_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_bus_out.html)
 
 ### BusOut Hello World!
 

--- a/docs/reference/api/drivers/CAN.md
+++ b/docs/reference/api/drivers/CAN.md
@@ -6,7 +6,7 @@ Controller-Area Network (CAN) is a bus standard that allows microcontrollers and
 
 ### CAN class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_c_a_n.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_c_a_n.html)
 
 ### CAN Hello World!
 

--- a/docs/reference/api/drivers/DigitalIn.md
+++ b/docs/reference/api/drivers/DigitalIn.md
@@ -8,7 +8,7 @@ You can use any of the numbered Arm Mbed pins can be used as a DigitalIn.
 
 API summary
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_digital_in.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_digital_in.html)
 
 ### DigitalIn hello, world
 

--- a/docs/reference/api/drivers/DigitalInOut.md
+++ b/docs/reference/api/drivers/DigitalInOut.md
@@ -11,7 +11,7 @@ You can use any of the numbered Arm Mbed pins as a DigitalInOut.
 
 ### DigitalInOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_digital_in_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_digital_in_out.html)
 
 ### DigitalInOut hello, world
 

--- a/docs/reference/api/drivers/DigitalOut.md
+++ b/docs/reference/api/drivers/DigitalOut.md
@@ -4,7 +4,7 @@ Use the DigitalOut interface to configure and control a digital output pin by se
 
 ### DigitalOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_digital_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_digital_out.html)
 
 ### DigitalOut hello, world
 

--- a/docs/reference/api/drivers/FlashIAP.md
+++ b/docs/reference/api/drivers/FlashIAP.md
@@ -22,7 +22,7 @@ This class is thread-safe.
 
 View the full C++ API:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_flash_i_a_p.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_flash_i_a_p.html)
 
 ### Flash IAP example
 

--- a/docs/reference/api/drivers/I2C.md
+++ b/docs/reference/api/drivers/I2C.md
@@ -11,7 +11,7 @@ All drivers on the I2C bus are required to be open collector, and so it is neces
 
 <span class="notes">**Note:** The Arm Mbed API uses 8 bit addresses, so make sure to left-shift 7 bit addresses by 1 bit before passing them. </span>
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_i2_c.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_i2_c.html)
 
 ### I2C hello, world
 

--- a/docs/reference/api/drivers/I2CSlave.md
+++ b/docs/reference/api/drivers/I2CSlave.md
@@ -6,7 +6,7 @@ Synchronization level: not protected.
 
 ### I2CSlave class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_i2_c_slave.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_i2_c_slave.html)
 
 ### I2CSlave example
 

--- a/docs/reference/api/drivers/InterruptIn.md
+++ b/docs/reference/api/drivers/InterruptIn.md
@@ -4,7 +4,7 @@ Use the InterruptIn interface to trigger an event when a digital input pin chang
 
 ### InterruptIn class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_interrupt_in.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_interrupt_in.html)
 
 **Warnings:**
 

--- a/docs/reference/api/drivers/LowPowerTicker.md
+++ b/docs/reference/api/drivers/LowPowerTicker.md
@@ -12,7 +12,7 @@ You can create any number of LowPowerTicker objects, allowing multiple outstandi
 
 ### LowPowerTicker class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_low_power_ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_low_power_ticker.html)
 
 ### LowPowerTicker example
 

--- a/docs/reference/api/drivers/LowPowerTimeout.md
+++ b/docs/reference/api/drivers/LowPowerTimeout.md
@@ -4,7 +4,7 @@
 
 ### LowPowerTimeout class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_low_power_timeout.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_low_power_timeout.html)
 
 ### LowPowerTimeout example
 

--- a/docs/reference/api/drivers/LowPowerTimer.md
+++ b/docs/reference/api/drivers/LowPowerTimer.md
@@ -4,7 +4,7 @@
 
 ### LowPowerTimer class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_low_power_timer.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_low_power_timer.html)
 
 ### LowPowerTimer example
 

--- a/docs/reference/api/drivers/PortIn.md
+++ b/docs/reference/api/drivers/PortIn.md
@@ -6,7 +6,7 @@ A mask can be supplied so only certain bits of a port are used, allowing other b
 
 ### PortIn class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_port_in.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_port_in.html)
 
 ### PortIn hello, world
 

--- a/docs/reference/api/drivers/PortInOut.md
+++ b/docs/reference/api/drivers/PortInOut.md
@@ -6,7 +6,7 @@ A mask can be supplied so you only use certain parts of a port, allowing other b
 
 ### PortInOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_port_in_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_port_in_out.html)
 
 ### PortInOut hello, world
 

--- a/docs/reference/api/drivers/PortOut.md
+++ b/docs/reference/api/drivers/PortOut.md
@@ -6,7 +6,7 @@ A mask can be supplied so only certain bits of a port are used, allowing other b
 
 ### PortOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_port_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_port_out.html)
 
 ### PortOut hello, world
 

--- a/docs/reference/api/drivers/PwmOut.md
+++ b/docs/reference/api/drivers/PwmOut.md
@@ -9,7 +9,7 @@ Use the PwmOut interface to control the frequency and duty cycle of a PWM signal
 
 ### PwmOut class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_pwm_out.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_pwm_out.html)
 
 
 ### PwmOut hello, world

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -18,7 +18,7 @@ _9600-8-N-1_, a  common notation for serial port settings, describes the default
 
 ### RawSerial class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_raw_serial.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_raw_serial.html)
 
 <span class="notes">**Note**: On a Windows machine, you need to install a USB serial driver. See <a href="/docs/v5.7/tutorials/serial-communication.html#windows-serial-driver" target="_blank">Windows serial configuration</a>.</span>
 

--- a/docs/reference/api/drivers/SPI.md
+++ b/docs/reference/api/drivers/SPI.md
@@ -23,7 +23,7 @@ The SPI master generates a clock to synchronously drive a serial bit stream slav
 
 ### SPI class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_s_p_i.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_s_p_i.html)
 
 ### SPI hello, world
 

--- a/docs/reference/api/drivers/SPISlave.md
+++ b/docs/reference/api/drivers/SPISlave.md
@@ -6,7 +6,7 @@ The default format is set to 8 bits, mode 0 and a clock frequency of 1MHz. Synch
 
 ### SPISlave class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_s_p_i_slave.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_s_p_i_slave.html)
 
 ### SPISlave example
 

--- a/docs/reference/api/drivers/Serial.md
+++ b/docs/reference/api/drivers/Serial.md
@@ -6,7 +6,7 @@ One of the serial connections uses the Arm Mbed USB port, allowing you to easily
 
 ### Serial class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_serial.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_serial.html)
 
 <span class="notes">**Note**: On a Windows machine, you will need to install a USB serial driver. See <a href="/docs/v5.7/tutorials/windows-serial-driver.html" target="_blank">Windows serial configuration</a>.</span>
 

--- a/docs/reference/api/drivers/Ticker.md
+++ b/docs/reference/api/drivers/Ticker.md
@@ -14,7 +14,7 @@ You can create any number of Ticker objects, allowing multiple outstanding inter
 
 ### Ticker class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_ticker.html)
 
 ### Ticker hello, world
 

--- a/docs/reference/api/drivers/TimeOut.md
+++ b/docs/reference/api/drivers/TimeOut.md
@@ -14,7 +14,7 @@ You can create any number of Timeout objects, allowing multiple outstanding inte
 
 ### Timeout class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_timeout.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_timeout.html)
 
 ### Timeout hello, world
 

--- a/docs/reference/api/drivers/Timer.md
+++ b/docs/reference/api/drivers/Timer.md
@@ -8,7 +8,7 @@ You can independently create, start and stop any number of Timer objects.
 
 ### Timer class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_timer.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_timer.html)
 
 ### Timer hello, world
 

--- a/docs/reference/api/platform/ATCmdParser.md
+++ b/docs/reference/api/platform/ATCmdParser.md
@@ -10,7 +10,7 @@ To use the ATCmdParser, the entity creating the ATCmdParser object passes a refe
 
 ### ATCmdParser class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_a_t_cmd_parser.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_a_t_cmd_parser.html)
 
 ### ATCmdParser examples
 

--- a/docs/reference/api/platform/Assert.md
+++ b/docs/reference/api/platform/Assert.md
@@ -4,7 +4,7 @@ Mbed OS provides a set of macros that evaluates an expression and prints an erro
 
 ### Assert macros reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__assert_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__assert_8h_source.html)
 
 ### Assert example
 

--- a/docs/reference/api/platform/Callback.md
+++ b/docs/reference/api/platform/Callback.md
@@ -6,7 +6,7 @@ This is the technical reference for callbacks. You should read the <a href="/doc
 
 ### Callback class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_callback_3_01_r_07_a0_00_01_a1_00_01_a2_00_01_a3_00_01_a4_08_4.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_callback_3_01_r_07_a0_00_01_a1_00_01_a2_00_01_a3_00_01_a4_08_4.html)
 
 ### Serial passthrough example with callbacks
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/rtos_threading_with_callback/)](https://os.mbed.com/users/mbedAustin/code/SerialPassthrough/file/96cb82af9996/main.cpp)

--- a/docs/reference/api/platform/CircularBuffer.md
+++ b/docs/reference/api/platform/CircularBuffer.md
@@ -16,7 +16,7 @@ CircularBuffer<int, BUF_SIZE> buf;
 
 ### CircularBuffer class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/_circular_buffer_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/_circular_buffer_8h_source.html)
 
 ### CircularBuffer example
 

--- a/docs/reference/api/platform/CriticalSectionLock.md
+++ b/docs/reference/api/platform/CriticalSectionLock.md
@@ -8,7 +8,7 @@ CriticalSectionLock class is based on RAII approach. In other words, the constru
 
 ### CriticalSectionLock class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_critical_section_lock.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_critical_section_lock.html)
 
 ### CriticalSectionLock example
 

--- a/docs/reference/api/platform/Debug.md
+++ b/docs/reference/api/platform/Debug.md
@@ -24,7 +24,7 @@ void *operator new(std::size_t count) {
 ```
 ### Debug functions reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__debug_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__debug_8h_source.html)
 
 ### Debug example
 

--- a/docs/reference/api/platform/DeepSleepLock.md
+++ b/docs/reference/api/platform/DeepSleepLock.md
@@ -6,7 +6,7 @@ The `DeepSleepLock` class provides an RAII object for disabling sleep. In other 
 
 ### DeepSleepLock class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_deep_sleep_lock.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_deep_sleep_lock.html)
 
 ### Example
 

--- a/docs/reference/api/platform/Error.md
+++ b/docs/reference/api/platform/Error.md
@@ -4,7 +4,7 @@ Mbed OS provides an error function to output messages to `STDIO` at runtime when
 
 ### Error function reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__error_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__error_8h_source.html)
 
 ### Error example
 

--- a/docs/reference/api/platform/FilePath.md
+++ b/docs/reference/api/platform/FilePath.md
@@ -3,7 +3,7 @@
 [Add description here.]
 
 ### FilePath class reference
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file_path.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file_path.html)
 
 ### FilePath example
 

--- a/docs/reference/api/platform/MemoryStats.md
+++ b/docs/reference/api/platform/MemoryStats.md
@@ -7,7 +7,7 @@ Mbed OS provides a set of functions that you can use to capture the memory stati
 
 ### MemoryStats functions reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__stats_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__stats_8h_source.html)
 
 ### MemoryStats example
 

--- a/docs/reference/api/platform/NonCopyable.md
+++ b/docs/reference/api/platform/NonCopyable.md
@@ -6,7 +6,7 @@ We recommend using the NonCopyable class whenever a class owns a resource (lock/
 
 ### NonCopyable class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_non_copyable.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_non_copyable.html)
 
 ### NonCopyable example
 

--- a/docs/reference/api/platform/PlatformMutex.md
+++ b/docs/reference/api/platform/PlatformMutex.md
@@ -4,7 +4,7 @@
 
 ### PlatformMutex class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_platform_mutex.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_platform_mutex.html)
 
 ### PlatformMutex example
 

--- a/docs/reference/api/platform/Rtc.md
+++ b/docs/reference/api/platform/Rtc.md
@@ -10,7 +10,7 @@ RTC can keep track of time even in a powered down state if the secondary source 
 
 ### RTC Time class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__rtc__time_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__rtc__time_8h_source.html)
 
 ### RTC Time example
 

--- a/docs/reference/api/platform/SleepManager.md
+++ b/docs/reference/api/platform/SleepManager.md
@@ -52,7 +52,7 @@ These Mbed OS drivers contain locking deep sleep:
 
 ### Sleep manager function reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__sleep_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__sleep_8h_source.html)
 
 ### Example
 

--- a/docs/reference/api/platform/Stream.md
+++ b/docs/reference/api/platform/Stream.md
@@ -4,7 +4,7 @@
 
 ### Stream class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_stream.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_stream.html)
 
 ### Stream example
 

--- a/docs/reference/api/platform/Time.md
+++ b/docs/reference/api/platform/Time.md
@@ -8,7 +8,7 @@ You cannot use `mktime` and `localtime` C standard library functions in an inter
 
 ### Time class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__mktime_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/mbed__mktime_8h_source.html)
 
 ### Time example
 

--- a/docs/reference/api/rtos/ConditionVariable.md
+++ b/docs/reference/api/rtos/ConditionVariable.md
@@ -4,7 +4,7 @@ The ConditionVariable class provides a mechanism to safely wait for or signal st
 
 ### ConditionVariable class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_condition_variable.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_condition_variable.html)
 
 ### ConditionVariable example
 

--- a/docs/reference/api/rtos/Event.md
+++ b/docs/reference/api/rtos/Event.md
@@ -4,7 +4,7 @@ The event loop is a mechanism that you can use to defer the execution of code to
 
 ### Event class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classevents_1_1_event_queue.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classevents_1_1_event_queue.html)
 
 ### Event example: deferring from interrupt context
 

--- a/docs/reference/api/rtos/EventFlags.md
+++ b/docs/reference/api/rtos/EventFlags.md
@@ -4,7 +4,7 @@ The EventFlags class is a C++ wrapper over the Keil RTX EventFlags functionality
 
 ### EventFlag class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_event_flags.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_event_flags.html)
 
 ### EventFlags example
 

--- a/docs/reference/api/rtos/EventQueue.md
+++ b/docs/reference/api/rtos/EventQueue.md
@@ -4,7 +4,7 @@
 
 ### EventQueue class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classevents_1_1_event_queue.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classevents_1_1_event_queue.html)
 
 ### EventQueue example
 

--- a/docs/reference/api/rtos/Mail.md
+++ b/docs/reference/api/rtos/Mail.md
@@ -6,7 +6,7 @@ Mail works like a queue, with the added benefit of providing a memory pool for a
 
 ### Mail class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_mail.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_mail.html)
 
 ### Mail example
 

--- a/docs/reference/api/rtos/MemoryPool.md
+++ b/docs/reference/api/rtos/MemoryPool.md
@@ -4,7 +4,7 @@ You can use the MemoryPool class to define and manage fixed-size memory pools.
 
 ### MemoryPool class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_memory_pool.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_memory_pool.html)
 
 ### MemoryPool example
 

--- a/docs/reference/api/rtos/Mutex.md
+++ b/docs/reference/api/rtos/Mutex.md
@@ -8,7 +8,7 @@ A Mutex is used to synchronize the execution of threads, for example to protect 
 
 ### Mutex class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_mutex.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_mutex.html)
 
 ### Mutex example
 

--- a/docs/reference/api/rtos/Queue.md
+++ b/docs/reference/api/rtos/Queue.md
@@ -6,7 +6,7 @@ A Queue allows you to queue pointers to data from producer threads to consumer t
 
 ### Queue class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_queue.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_queue.html)
 
 ### Queue example
 

--- a/docs/reference/api/rtos/RtosTimer.md
+++ b/docs/reference/api/rtos/RtosTimer.md
@@ -10,7 +10,7 @@ The thread `osTimerThread` handles timers. Callback functions run under the cont
 
 ### RtosTimer class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_rtos_timer.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_rtos_timer.html)
 
 ### RtosTimer example
 

--- a/docs/reference/api/rtos/Semaphore.md
+++ b/docs/reference/api/rtos/Semaphore.md
@@ -6,7 +6,7 @@ A semaphore manages thread access to a pool of shared resources of a certain typ
 
 ### Semaphore class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_semaphore.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_semaphore.html)
 
 ### Semaphore example
 

--- a/docs/reference/api/rtos/Thread.md
+++ b/docs/reference/api/rtos/Thread.md
@@ -6,7 +6,7 @@ The Thread class allows defining, creating and controlling parallel tasks.
 
 ### Thread class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_thread.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classrtos_1_1_thread.html)
 
 <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/thread_priority.png)</span>
 

--- a/docs/reference/api/storage/BlockDevice.md
+++ b/docs/reference/api/storage/BlockDevice.md
@@ -4,7 +4,7 @@ The BlockDevice API provides an interface for access to block-based storage. You
 
 ### BlockDevice class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_block_device.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_block_device.html)
 
 <a href="https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h" target="_blank">C++ API Reference</a>
 

--- a/docs/reference/api/storage/ChainingBlockDevice.md
+++ b/docs/reference/api/storage/ChainingBlockDevice.md
@@ -8,7 +8,7 @@ The constructor takes in an array of block device pointers and provides an objec
 
 ### ChainingBlockDevice class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_chaining_block_device.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_chaining_block_device.html)
 
 ### ChainingBlockDevice example
 

--- a/docs/reference/api/storage/Dir.md
+++ b/docs/reference/api/storage/Dir.md
@@ -4,7 +4,7 @@
 
 ### Dir class API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_dir.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_dir.html)
 
 ### Dir example
 

--- a/docs/reference/api/storage/FATFileSystem.md
+++ b/docs/reference/api/storage/FATFileSystem.md
@@ -4,7 +4,7 @@
 
 ### FATFileSystem class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_f_a_t_file_system.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_f_a_t_file_system.html)
 
 ### FATFileSystem example
 

--- a/docs/reference/api/storage/File.md
+++ b/docs/reference/api/storage/File.md
@@ -4,7 +4,7 @@
 
 ### File class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file.html)
 
 ### File example
 

--- a/docs/reference/api/storage/FileSystem.md
+++ b/docs/reference/api/storage/FileSystem.md
@@ -4,7 +4,7 @@ The file system API provides a common interface for implementing a file system o
 
 ### File system class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file_system.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file_system.html)
 
 ### File system example
 

--- a/docs/reference/api/storage/HeapBlockDevice.md
+++ b/docs/reference/api/storage/HeapBlockDevice.md
@@ -22,7 +22,7 @@ You can view more information about the configurable settings and functions in t
 
 ### HeapBlockDevice class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_heap_block_device.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_heap_block_device.html)
 
 ### HeapBlockDevice example
 

--- a/docs/reference/api/storage/LittleFileSystem.md
+++ b/docs/reference/api/storage/LittleFileSystem.md
@@ -35,7 +35,7 @@ The API that this presents is the standard Mbed OS file system API. Once declare
 
 ### LittleFileSystem class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_little_file_system.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_little_file_system.html)
 
 ### LittleFileSystem example
 

--- a/docs/reference/api/storage/MBRBlockDevice.md
+++ b/docs/reference/api/storage/MBRBlockDevice.md
@@ -11,7 +11,7 @@ You can view more information about the configurable settings and functions in t
 
 ### MBRBlockDevice class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_m_b_r_block_device.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_m_b_r_block_device.html)
 
 ### MBRBlockDevice example
 

--- a/docs/reference/api/storage/ProfilingBlockDevice.md
+++ b/docs/reference/api/storage/ProfilingBlockDevice.md
@@ -6,7 +6,7 @@ ProfilingBlockDevices take in a pointer to the block device being profiled as th
 
 ### ProfilingBlockDevice class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_profiling_block_device.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_profiling_block_device.html)
 
 ### ProfilingBlockDevice example
 

--- a/docs/reference/api/storage/SlicingBlockDevice.md
+++ b/docs/reference/api/storage/SlicingBlockDevice.md
@@ -10,7 +10,7 @@ The constructor takes in the master block device pointer and the start and end a
 
 ### SlicingBlockDevice class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_slicing_block_device.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/class_slicing_block_device.html)
 
 ### SlicingBlockDevice example
 

--- a/docs/reference/contributing/storage/storage.md
+++ b/docs/reference/contributing/storage/storage.md
@@ -22,7 +22,7 @@ A minimal file system needs to provide the following functions:
 
 Here is the full API that a file system may implement:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file_system.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.7/mbed-os-api-doxy/classmbed_1_1_file_system.html)
 
 File systems must be backed by a block device in Mbed OS. If you are using supported hardware, then you can use the Mbed OS block device classes. Otherwise, view the [block device porting section](#block-device) earlier in this guide.
 


### PR DESCRIPTION
Lots of technical reasons this is required. This can be reverted back to `https` when we make the switch to the production URLs.

cc @AnotherButler @iriark01 