### PR TITLE
Fix MemoryPool docs to capture the difference between alloc/calloc

### DIFF
--- a/docs/reference/api/rtos/MemoryPool.md
+++ b/docs/reference/api/rtos/MemoryPool.md
@@ -1,6 +1,6 @@
 ## MemoryPool
 
-You can use the MemoryPool class to define and manage fixed-size memory pools. You can allocate memory blocks of fixed size from the pool using the `alloc` or `calloc` method, which returns a pointer to the block of memory or NULL if there is no space available in the pool. It's the user's responsibility to initialize the objects placed in blocks. The `calloc` function sets the block of memory to zeroes before returning the pointer of the block to the caller.   
+You can use the MemoryPool class to define and manage fixed-size memory pools. You can allocate memory blocks of fixed size from the pool using the `alloc` or `calloc` method, which returns a pointer to the block of memory or NULL if there is no space available in the pool. It's the user's responsibility to initialize the objects placed in blocks. The `calloc` function sets the block of memory to zeros before returning the pointer of the block to the caller.   
 
 ### MemoryPool class reference
 

--- a/docs/reference/api/rtos/MemoryPool.md
+++ b/docs/reference/api/rtos/MemoryPool.md
@@ -1,6 +1,6 @@
 ## MemoryPool
 
-You can use the MemoryPool class to define and manage fixed-size memory pools. You can allocate memory blocks of fixed size from the pool using the `alloc` method, which returns a pointer to the block of memory or NULL if there is no space available in the pool. The `alloc` function sets the block of memory to zeroes before returning the pointer of the block to the caller. It's the user's responsibility to initialize the objects placed in blocks.  
+You can use the MemoryPool class to define and manage fixed-size memory pools. You can allocate memory blocks of fixed size from the pool using the `alloc` or `calloc` method, which returns a pointer to the block of memory or NULL if there is no space available in the pool. It's the user's responsibility to initialize the objects placed in blocks. The `calloc` function sets the block of memory to zeroes before returning the pointer of the block to the caller.   
 
 ### MemoryPool class reference
 


### PR DESCRIPTION
Fix the documentation to clarify that its the calloc function which sets the memory to zeroes.