### PR TITLE
AStyle update (use options and ignore file for astyle)

### DIFF
--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -14,7 +14,7 @@ Whether you're writing new code or fixing bugs in existing code, please follow t
 
 Mbed OS follows the [K&R style](https://en.wikipedia.org/wiki/Indent_style#K.26R_style), with at least two exceptions (which can be found in the list below the code sample).
 
-The only exception to this coding style are 3rd parties libraries. The 3rd party libraries should be added to the `.astyleignore` file located in the Mbed OS root directory.
+The only exception to this coding style are third-party code. Third-party code should be added to the `.astyleignore` file located in the Mbed OS root directory.
 
 You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
 

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -159,8 +159,10 @@ All functions and methods should contain documentation using Doxgyen.
 You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
 
 ```
-astyle --style=kr --indent=spaces=4 --indents-switches $(full_path_to_file)
+astyle -n --options=.astylerc $(full_path_to_file)
 ```
+
+File `.astylerc` defines Mbed OS code style and it's located in Mbed OS root directory.
 
 #### Compiler settings
 

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -16,6 +16,14 @@ Mbed OS follows the [K&R style](https://en.wikipedia.org/wiki/Indent_style#K.26R
 
 The only exception to this coding style are 3rd parties libraries. The 3rd party libraries should be added to the `.astyleignore` file located in the Mbed OS root directory.
 
+You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
+
+```
+astyle -n --options=.astylerc $(full_path_to_file)
+```
+
+File `.astylerc` defines Mbed OS code style and it's located in Mbed OS root directory.
+
 ##### Code sample
 
 ```c
@@ -157,14 +165,6 @@ typedef struct analogin_s analogin_t;
 ##### Doxygen documentation
 
 All functions and methods should contain documentation using Doxgyen.
-
-You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
-
-```
-astyle -n --options=.astylerc $(full_path_to_file)
-```
-
-File `.astylerc` defines Mbed OS code style and it's located in Mbed OS root directory.
 
 #### Compiler settings
 

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -14,6 +14,8 @@ Whether you're writing new code or fixing bugs in existing code, please follow t
 
 Mbed OS follows the [K&R style](https://en.wikipedia.org/wiki/Indent_style#K.26R_style), with at least two exceptions (which can be found in the list below the code sample).
 
+The only exception to this coding style are 3rd parties libraries. The 3rd party libraries should be added to the `.astyleignore` file located in the Mbed OS root directory.
+
 ##### Code sample
 
 ```c

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -159,7 +159,7 @@ All functions and methods should contain documentation using Doxgyen.
 You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
 
 ```
-astyle.exe --style=kr --indent=spaces=4 --indents-switches $(full_path_to_file)
+astyle --style=kr --indent=spaces=4 --indents-switches $(full_path_to_file)
 ```
 
 #### Compiler settings

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -14,7 +14,7 @@ Whether you're writing new code or fixing bugs in existing code, please follow t
 
 Mbed OS follows the [K&R style](https://en.wikipedia.org/wiki/Indent_style#K.26R_style), with at least two exceptions (which can be found in the list below the code sample).
 
-The only exception to this coding style are third-party code. Third-party code should be added to the `.astyleignore` file located in the Mbed OS root directory.
+The only exception to this coding style involves third-party code. Third-party code should be added to the `.astyleignore` file located in the Mbed OS root directory.
 
 You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
 


### PR DESCRIPTION
Depends on https://github.com/ARMmbed/mbed-os/pull/6014 (once it lands), we got astyle options and ignore paths.

I added documentation to cover the new option file and ignore paths (a mention that 3rd parties libraries should not be formatted).

Any other suggestions for this update? We are adding this check to travis, shall we mention it there  that automatic checks are done for all changes?

@adbridge @theotherjimmy @cmonr @kjbracey-arm Please review (@AnotherButler can you add them as reviewers)