### PR TITLE
fix typo in astyle command line options

### DIFF
--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -159,7 +159,7 @@ All functions and methods should contain documentation using Doxgyen.
 You can use [Artistic Style (AStyle)](http://sourceforge.net/projects/astyle/files/) to format your code. Use the command-line switch to select the correct style and point to the file you want to edit:
 
 ```
-astyle.exe --style=kr --indent=spaces=4 --indents-switches $(full_path_to_file)
+astyle.exe --style=kr --indent=spaces=4 --indent-switches $(full_path_to_file)
 ```
 
 #### Compiler settings


### PR DESCRIPTION
Just a minor thing, I tried the suggested astyle command line options and got an error

I changed `--indents-switches` to `--indent-switches` and it worked