### PR TITLE
Replace references to heapblock with blockdevice

### DIFF
--- a/docs/reference/contributing/storage/storage.md
+++ b/docs/reference/contributing/storage/storage.md
@@ -4,13 +4,13 @@ Storage support is split between file systems and their underlying block device 
 
 #### Block Device
 
-Adding a block device implementation is required for backing filesystems on new hardware. You can extend the [BlockDevice](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_block_device.html) class to provide support for unsupported storage. 
+Adding a block device implementation is required for backing filesystems on new hardware. You can extend the [BlockDevice](https://os.mbed.com/docs/v5.7/mbed-os-api-doxy/class_block_device.html) class to provide support for unsupported storage. 
 
 If you want to port a new file system to Mbed OS on existing storage options you can skip to the following section.
 
 #### File systems
 
-To implement a new file system in Mbed OS, an implementor needs to provide the abstract functions in the file system interface. The [FAT file system](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_f_a_t_file_system.html) provides an excellent example.
+To implement a new file system in Mbed OS, an implementor needs to provide the abstract functions in the file system interface. The [FAT file system](https://os.mbed.com/docs/v5.7/mbed-os-api-doxy/class_f_a_t_file_system.html) provides an excellent example.
 
 A minimal file system needs to provide the following functions:
 
@@ -28,5 +28,5 @@ File systems must be backed by a block device in Mbed OS. If you are using suppo
 
 #### Related content
 
-- [BlockDevice](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_block_device.html).
-- [FAT file system](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_f_a_t_file_system.html).
+- [BlockDevice](https://os.mbed.com/docs/v5.7/mbed-os-api-doxy/class_block_device.html).
+- [FAT file system](https://os.mbed.com/docs/v5.7/mbed-os-api-doxy/class_f_a_t_file_system.html).

--- a/docs/reference/contributing/storage/storage.md
+++ b/docs/reference/contributing/storage/storage.md
@@ -4,7 +4,7 @@ Storage support is split between file systems and their underlying block device 
 
 #### Block Device
 
-Adding a block device implementation is required for backing filesystems on new hardware. You can extend the [BlockDevice](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_heap_block_device.html) class to provide support for unsupported storage. 
+Adding a block device implementation is required for backing filesystems on new hardware. You can extend the [BlockDevice](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_block_device.html) class to provide support for unsupported storage. 
 
 If you want to port a new file system to Mbed OS on existing storage options you can skip to the following section.
 
@@ -28,5 +28,5 @@ File systems must be backed by a block device in Mbed OS. If you are using suppo
 
 #### Related content
 
-- [BlockDevice](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_heap_block_device.html).
+- [BlockDevice](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_block_device.html).
 - [FAT file system](https://os.mbed.com/docs/v5.6/mbed-os-api-doxy/class_f_a_t_file_system.html).


### PR DESCRIPTION
HeapBlockDevice is an inheritor of the BlockDevice class. The related content and block device porting section should reference extending the BlockDevice class, not one of its implementations.

@AnotherButler 