### PR TITLE
Contr API Ref Typos

### DIFF
--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -48,7 +48,7 @@ We are working on the new HAL low power ticker API, which will replace the curre
 
 To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-ticker` branch. You can find the API and specification for the new low power ticker API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
 
 To enable low power ticker support in Mbed OS, add the `LOWPOWERTIMER` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -62,8 +62,8 @@ mbed test -t <toolchain> -m <target> -n tests-mbed_hal-lp_us_ticker*,tests-mbed_
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__ticker__tests.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker__tests.html)

--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -16,7 +16,7 @@ Implementing the low power ticker enables Mbed OS to perform power efficient tim
 - The ticker rolls over at (1 << bits) and continues counting starting from 0.
 - The ticker counts at the specified frequency plus or minus 10%.
 - The ticker increments by 1 each tick.
-- The ticker interrupt fires only when the ticker times increments to or past the value that `ticker_set_interrupt` sets.
+- The ticker interrupt fires only when the ticker time increments to or past the value that `ticker_set_interrupt` sets.
 - It is safe to call `ticker_set_interrupt` repeatedly before the handler is called.
 - The function `ticker_fire_interrupt` causes `ticker_irq_handler` to be called immediately from interrupt context.
 - The ticker operations `ticker_read`, `ticker_clear_interrupt`, `ticker_set_interrupt` and `ticker_fire_interrupt` take less than 20us to complete.
@@ -34,7 +34,7 @@ Be careful around these common trouble areas when implementing this API:
 
 - The ticker cannot drift when rescheduled repeatedly
 - The ticker keeps counting when it rolls over
-- The ticker interrupts fires when the compare value is set to 0 and and overflow occurs
+- The ticker interrupt fires when the compare value is set to 0 and and overflow occurs
 
 #### Dependencies
 
@@ -42,11 +42,11 @@ Hardware low power ticker capabilities.
 
 #### Implementing the low power ticker API
 
-We are working on the new HAL low power ticker API, which will replace current version in an upcoming release of Mbed OS. You need to implement the low power ticker API in both variants. First, you need to implement the current API. You can find it on master branch:
+We are working on the new HAL low power ticker API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the low power ticker API in both variants. First, you need to implement the current API. You can find it on master branch:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/lp__ticker__api_8h_source.html)
 
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against `feature-hal-spec-ticker` branch. You can find the API and specification for the new low power ticker API in the following header file:
+To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-ticker` branch. You can find the API and specification for the new low power ticker API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
 

--- a/docs/reference/contributing/target/rtc.md
+++ b/docs/reference/contributing/target/rtc.md
@@ -38,7 +38,7 @@ We are working on the new HAL RTC API, which will replace the current version in
 
 To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-rtc` branch. You can find the API and specification for the new RTC API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-rtc-doxy/group__hal__rtc.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-rtc-doxy/group__hal__rtc.html)
 
 To enable RTC support in Mbed OS, add the `RTC` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -52,4 +52,4 @@ mbed test -t <toolchain> -m <target> -n "tests-mbed_hal-rtc*"
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-rtc-doxy/group__hal__rtc__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-rtc-doxy/group__hal__rtc__tests.html)

--- a/docs/reference/contributing/target/rtc.md
+++ b/docs/reference/contributing/target/rtc.md
@@ -32,11 +32,11 @@ Hardware RTC capabilities.
 
 #### Implementing the RTC API
 
-We are working on the new HAL RTC API, which will replace current version in an upcoming release of Mbed OS. You need to implement the RTC API in both variants. First, you need to implement the current API. You can find it on the master branch:
+We are working on the new HAL RTC API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the RTC API in both variants. First, you need to implement the current API. You can find it on the master branch:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/rtc__api_8h_source.html)
 
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against `feature-hal-spec-rtc` branch. You can find the API and specification for the new RTC API in the following header file:
+To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-rtc` branch. You can find the API and specification for the new RTC API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-rtc-doxy/group__hal__rtc.html)
 

--- a/docs/reference/contributing/target/sleep.md
+++ b/docs/reference/contributing/target/sleep.md
@@ -32,7 +32,7 @@ We are working on the new HAL Sleep API, which will replace the current version 
 
 To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-sleep` branch. You can find the API and specification for the new Sleep API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep.html)
 
 To enable sleep support in Mbed OS, you need to add the `SLEEP` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -46,4 +46,4 @@ mbed test -t <toolchain> -m <target> -n "tests-mbed_hal-sleep*"
 
 You can read more about the test cases:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep__tests.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep__tests.html)

--- a/docs/reference/contributing/target/sleep.md
+++ b/docs/reference/contributing/target/sleep.md
@@ -8,7 +8,7 @@ Implement the Sleep HAL API to enable your device to go into a low power state w
 
 ##### Defined behavior
 
-There are two power saving modes available in Mbed OS:
+There are two power-saving modes available in Mbed OS:
 
 ###### Sleep
 
@@ -26,11 +26,11 @@ The core system clock is disabled. You can only enable the low-frequency clocks 
 
 #### Implementing the Sleep API
 
-We are working on the new HAL Sleep API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the Sleep API in both variants. First, you need to implement the current API. You can find it on master branch:
+We are working on the new HAL Sleep API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the Sleep API in both variants. First, you need to implement the current API. You can find it on the master branch:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/sleep__api_8h_source.html)
 
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against `feature-hal-spec-sleep` branch. You can find the API and specification for the new Sleep API in the following header file:
+To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-sleep` branch. You can find the API and specification for the new Sleep API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep.html)
 

--- a/docs/reference/contributing/target/us_ticker.md
+++ b/docs/reference/contributing/target/us_ticker.md
@@ -48,7 +48,7 @@ We are working on the new HAL microsecond ticker API, which will replace the cur
 
 To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-ticker` branch. You can find the API and specification for the new microsecond ticker API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
 
 To enable microsecond ticker support in Mbed OS, add the `USTICKER` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -62,8 +62,8 @@ mbed test -t <toolchain> -m <target> -n tests-mbed_hal-lp_us_ticker*,tests-mbed_
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__ticker__tests.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker__tests.html)

--- a/docs/reference/contributing/target/us_ticker.md
+++ b/docs/reference/contributing/target/us_ticker.md
@@ -1,6 +1,6 @@
 ### Microsecond ticker
 
-Implementing the microsecond ticker enables Mbed OS to perform operations that require precise timing. You can use this API to shedule events, record elapsed time and perform submillisecond delays.
+Implementing the microsecond ticker enables Mbed OS to perform operations that require precise timing. You can use this API to schedule events, record elapsed time and perform submillisecond delays.
 
 <span class="warnings">**Warning:** We are changing the microsecond ticker HAL API in an upcoming release of Mbed OS. You can find details on how it may affect you in the [implementing the microsecond ticker API](#implementing-the-microsecond-ticker-api) section.
 
@@ -16,7 +16,7 @@ Implementing the microsecond ticker enables Mbed OS to perform operations that r
 - The ticker rolls over at (1 << bits) and continues counting starting from 0.
 - The ticker counts at the specified frequency plus or minus 10%.
 - The ticker increments by 1 each tick.
-- The ticker interrupt fires only when the ticker times increments to or past the value set by `ticker_set_interrupt`.
+- The ticker interrupt fires only when the ticker time increments to or past the value set by `ticker_set_interrupt`.
 - It is safe to call `ticker_set_interrupt` repeatedly before the handler is called.
 - The function `ticker_fire_interrupt` causes `ticker_irq_handler` to be called immediately from interrupt context.
 - The ticker operations `ticker_read`, `ticker_clear_interrupt`, `ticker_set_interrupt` and `ticker_fire_interrupt` take less than 20us to complete.
@@ -34,7 +34,7 @@ Be careful around these common trouble areas when implementing this API:
 
 - The ticker cannot drift when rescheduled repeatedly
 - The ticker keeps counting when it rolls over
-- The ticker interrupts fires when the compare value is set to 0 and and overflow occurs
+- The ticker interrupt fires when the compare value is set to 0 and overflow occurs
 
 #### Dependencies
 
@@ -42,11 +42,11 @@ To implement this API, the device must have a hardware counter that has a count 
 
 #### Implementing the microsecond ticker API
 
-We are working on the new HAL microsecond ticker API, which will replace current version in an upcoming release of Mbed OS. You need to implement the microsecond ticker API in both variants. First, you need to implement the current API. You can find it on master branch:
+We are working on the new HAL microsecond ticker API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the microsecond ticker API in both variants. First, you need to implement the current API. You can find it on the master branch:
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/us__ticker__api_8h_source.html)
 
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against `feature-hal-spec-ticker` branch. You can find the API and specification for the new microsecond ticker API in the following header file:
+To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-ticker` branch. You can find the API and specification for the new microsecond ticker API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
 


### PR DESCRIPTION
Just a few typos.

I'm assuming that the phrase 'ticker times increments' is meant to be singular 'time' that increments, but they may also mean that ticker 'times' (plural) increment (without the 's'). Either way, one needs to be changed.
