### PR TITLE
TBD corrections 3

### DIFF
--- a/docs/reference/api/connectivity/bluetooth/Gap.md
+++ b/docs/reference/api/connectivity/bluetooth/Gap.md
@@ -4,9 +4,9 @@ The Generic Access Profile is the layer of the stack that handles connectivity t
 
 Devices with data to publish can use GAP to advertise. They can include the data in the advertisement itself, inside the scan response, or leave a peer device to query it after the connection has been established.
 
-The other side of the process is the act of scanning, which listens for advertisements, allows you to query the advertisers for more data through a scan request, or connect in order to query the peer device for the data you want.
+The other side of the process is the act of scanning, which listens for advertisements, allows you to query the advertisers for more data through a scan request or connect in order to query the peer device for the data you want.
 
-Advertising, scanning and connection all have parameters that let you find a compromise between desired power consumption levels, latency, and efficiency of these processes.
+Advertising, scanning and connection all have parameters that let you find a compromise between desired power consumption levels, latency and efficiency of these processes.
 
 ### GAP class reference
 

--- a/docs/reference/api/connectivity/bluetooth/Gap.md
+++ b/docs/reference/api/connectivity/bluetooth/Gap.md
@@ -2,11 +2,11 @@
 
 The Generic Access Profile is the layer of the stack that handles connectivity tasks. This includes link establishment and termination, advertising and scanning.
 
-Devices with data to publish can use GAP to advertise. They can include the data in the advertisement itself or inside the scan response or leave a peer device to query it after the connection has been established.
+Devices with data to publish can use GAP to advertise. They can include the data in the advertisement itself, inside the scan response, or leave a peer device to query it after the connection has been established.
 
-The other side of the process is the act of scanning, which listens for advertisements, allows you to query the advertisers for more data through a scan request or to connect in order to query the peer device for the data we want.
+The other side of the process is the act of scanning, which listens for advertisements, allows you to query the advertisers for more data through a scan request, or connect in order to query the peer device for the data you want.
 
-Advertising, scanning and connection all have parameters that let you find a compromise between desired power consumption levels and latency and efficiency of these processes.
+Advertising, scanning and connection all have parameters that let you find a compromise between desired power consumption levels, latency, and efficiency of these processes.
 
 ### GAP class reference
 

--- a/docs/reference/api/connectivity/bluetooth/SecurityManager.md
+++ b/docs/reference/api/connectivity/bluetooth/SecurityManager.md
@@ -2,9 +2,9 @@
 
 SecurityManager deals with authentication and encryption for the Bluetooth Low Energy link. The pairing and optionally bonding processes provide this. The SecurityManager achieves bonding by saving the pairing information and reusing it on subsequent reconnections. This saves time because the pairing does not have to be performed again.
 
-The pairing process may produce a set of keys to be used during current or later connections. The SecurityManager includes the Long Term Encryption Key (LTK), the Identity Resolving Key (IRK) and the Connection Signature Resolving Key (CSRK). The SecurityManager uses the LTK to encrypt subsequent connections without having to pair again. The Link Controller uses IRK to identify peers who use random resolvable addresses. The application uses CSRK to sign and authenticate signed data.
+The pairing process may produce a set of keys to be used during current or later connections. The SecurityManager handles these, and they include the Long Term Encryption Key (LTK), the Identity Resolving Key (IRK) and the Connection Signature Resolving Key (CSRK). The SecurityManager uses the LTK to encrypt subsequent connections without having to pair again. The Link Controller uses IRK to identify peers who use random resolvable addresses. The application uses CSRK to sign and authenticate signed data.
 
-The pairing process can provide man-in-the-middle protection (MITM). The SecurityManager achieves this through various means, including out of band communication, depending on the capabilities of the local and peer device.
+The pairing process may provide man-in-the-middle protection (MITM). The SecurityManager achieves this through various means, including out of band communication, depending on the capabilities of the local and peer device.
 
 The SecurityManager stores the keys, permanently if possible, to speed security requests on subsequent connections.
 
@@ -16,6 +16,6 @@ Security requests may come explicitly from the user application or implicitly fr
 
 ### SecurityManager example
 
-The SecurityManager example demonstrates both a central and a peripheral connecting, performing basic pairing, and setting up link security.
+The SecurityManager example demonstrates both a central and a peripheral connecting, performing basic pairing and setting up link security.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-SM/)](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-SM/file/fcb1e0b995a9/source/main.cpp)

--- a/docs/reference/api/connectivity/bluetooth/SecurityManager.md
+++ b/docs/reference/api/connectivity/bluetooth/SecurityManager.md
@@ -1,10 +1,10 @@
 ## SecurityManager
 
-SecurityManager deals with authentication and encryption for the Bluetooth Low Energy link. The process of pairing and optionally bonding provides this. The SecurityManager achieves bonding by saving the pairing information and reusing it on subsequent reconnections in order to save time by not having to perform pairing again.
+SecurityManager deals with authentication and encryption for the Bluetooth Low Energy link. The pairing and optionally bonding processes provide this. The SecurityManager achieves bonding by saving the pairing information and reusing it on subsequent reconnections. This saves time because the pairing does not have to be performed again.
 
-The process of pairing may produce a set of keys to be used during current or later connections. The SecurityManager and include the Long Term Encryption Key (LTK), the Identity Resolving Key (IRK) and the Connection Signature Resolving Key (CSRK) handle these. The SecurityManager uses the LTK to encrypt subsequent connections without having to pair again. The Link Controller uses IRK to identify peers who use random resolvable addresses. The application uses CSRK to sign and authenticate signed data.
+The pairing process may produce a set of keys to be used during current or later connections. The SecurityManager includes the Long Term Encryption Key (LTK), the Identity Resolving Key (IRK) and the Connection Signature Resolving Key (CSRK). The SecurityManager uses the LTK to encrypt subsequent connections without having to pair again. The Link Controller uses IRK to identify peers who use random resolvable addresses. The application uses CSRK to sign and authenticate signed data.
 
-The pairing process may provide man-in-the-middle protection (MITM). The SecurityManager achieves this through various means, including out of band communication, depending on the capabilities of the local and peer device.
+The pairing process can provide man-in-the-middle protection (MITM). The SecurityManager achieves this through various means, including out of band communication, depending on the capabilities of the local and peer device.
 
 The SecurityManager stores the keys, permanently if possible, to speed security requests on subsequent connections.
 

--- a/docs/reference/api/connectivity/bluetooth/SecurityManager.md
+++ b/docs/reference/api/connectivity/bluetooth/SecurityManager.md
@@ -16,6 +16,6 @@ Security requests may come explicitly from the user application or implicitly fr
 
 ### SecurityManager example
 
-The SecurityManager example demonstrates both a central and a peripheral connecting and performing basic pairing and setting up link security.
+The SecurityManager example demonstrates both a central and a peripheral connecting, performing basic pairing, and setting up link security.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-SM/)](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-SM/file/fcb1e0b995a9/source/main.cpp)


### PR DESCRIPTION
There were a few things that were unclear in this section:

In the 1st paragraph of the Security Manger section:
The phrase 'process of pairing and optionally bonding' in the 2nd sentence is a little confusing. Are these two parts of one process?, i.e. 'the pairing and optionally bonding process provides this'?  Or, are they two separate processes? - in which case it should say: 'The pairing and optionally bonding processes provide this.' (I took a guess from the context that they are two separate but related processes, and that the latter was meant?)

2nd paragraph of the Security Manager section:
I changed 'process of pairing' to 'pairing process' again (in the 3rd paragraph it is called the 'pairing process' and I thought this might sound better?)
The next sentence (2nd paragraph, 2nd sentence) - I can't tell what it is trying to say? (there must be words missing/added?) . I guessed that the Security Manager provides these keys listed, but I couldn't tell what 'handle these' at the end fo the sentence might refer to?

3rd paragraph:
I changed 'may' because it sounded like it may/may not provide this - so I changed it to 'can'
