### PR TITLE
Replace us_lp tests reference with common_ticker

### DIFF
--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -57,7 +57,7 @@ To enable low power ticker support in Mbed OS, add the `LPTICKER` label in the `
 The Mbed OS HAL provides a set of conformance tests for the low power ticker. You can use these tests to validate the correctness of your implementation. To run the low power ticker HAL tests, use the following command:
 
 ```
-mbed test -t <toolchain> -m <target> -n tests-mbed_hal-lp_us_ticker*,tests-mbed_hal-lp_ticker*
+mbed test -t <toolchain> -m <target> -n tests-mbed_hal-common_ticker*,tests-mbed_hal-lp_ticker*
 ```
 
 You can read more about the test cases:

--- a/docs/reference/contributing/target/us_ticker.md
+++ b/docs/reference/contributing/target/us_ticker.md
@@ -57,7 +57,7 @@ To enable microsecond ticker support in Mbed OS, add the `USTICKER` label in the
 The Mbed OS HAL provides a set of conformance tests for the microsecond ticker. You can use these tests to validate the correctness of your implementation. To run the microsecond ticker HAL tests, use the following command:
 
 ```
-mbed test -t <toolchain> -m <target> -n tests-mbed_hal-lp_us_ticker*,tests-mbed_hal-us_ticker*
+mbed test -t <toolchain> -m <target> -n tests-mbed_hal-common_ticker*,tests-mbed_hal-us_ticker*
 ```
 
 You can read more about the test cases:


### PR DESCRIPTION
Some of the tests were renamed not to confuse users, update porting guide to reflect this.

Code already merged to mbed-os repo.
