### PR TITLE
workflow: add PR types explanation

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -94,7 +94,7 @@ We consider the following pull request types.
 
 ##### Fix
 
-A bug fix should be backward-compatible internal change that fixes incorrect behavior. The fix should provide a description what and how it fixes the issue. The test should be included to catch this issue in the future and confirm the correct behavior.
+A bug fix is backward-compatible internal change that fixes incorrect behavior. The fix provides a description what and how it fixes the issue. Tests are included to catch the issue in the future and confirms the correct behavior.
 
 Release: patch
 
@@ -115,7 +115,7 @@ Release: patch
 
 New features targets feature releases. It can be integrated only if the feature supports most of the targets (if it requires new target HAL implementation).
 
-Adding a new functionality is considered to be a feature. It does not matter if it is C++ or C.
+Adding a new functionality is considered to be a feature. It does not matter if it is C++, C or Python.
 
 Release: feature
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -61,13 +61,13 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 - Avoid merging commmits. (Always rebase when possible.)
 - Pull requests should fix a bug, add a feature or refactor.
 
-#### Mbed OS release versioning
+#### Release versioning
 
-Version number MAJOR.FEATURE.PATCH where:
+The Mbed OS version number follows the format MAJOR.FEATURE.PATCH. We use the:
 
-- MAJOR version for incompatible API changes
-- FEATURE version for adding functionality in backward-compatible manner
-- PATCH version for backward-compatible bug fixes
+- MAJOR version for incompatible API changes.
+- FEATURE version for adding functionality in backward-compatible manner.
+- PATCH version for backward-compatible bug fixes.
 
 ### Pull request categories
 
@@ -94,33 +94,33 @@ We consider the following pull request types.
 
 ##### Fix
 
-A bug fix is backward-compatible internal change that fixes incorrect behavior.
+A bug fix is a backward-compatible internal change that fixes incorrect behavior.
 
 Release: patch
 
 ##### Refactor
 
-Refactors are intended for feature releases if they are not fixing specific issue as they can introduce new issues.
+Refactors are intended for feature releases if they are not fixing specific issues because they can introduce new issues.
 
 Release: feature
 
 ##### New target
 
-Adding a new target targets the patch release as it updating targets folder implementation.
+Adding a new target is a change for a patch release because it updates the targets folder implementation.
 
 Release: patch
 
 ##### Feature
 
-New features targets feature releases. It can be integrated only if the feature supports most of the targets (if it requires new target HAL implementation).
+New features target feature releases. A new feature can be integrated only if the feature supports most of the targets (if it requires new target HAL implementation).
 
-Adding a new functionality is considered to be a feature. It does not matter if it is C++, C or Python.
+We consider adding a new functionality to be a feature. It does not matter if it is C++, C or Python.
 
 Release: feature
 
 ##### Breaking change
 
-Any change that results in breaking user space. It should have strong justification to be considered. Often the change could be made backward compatible, for example deprecate the old functionality and introduce the new replacement.
+A breaking change is any change that results in breaking user space. It should have strong justification for us to consider it. Often, such changes can be backward compatible, for example, deprecating the old functionality and introducing the new replacement.
 
 Release: major
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -63,7 +63,7 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 
 #### Release versioning
 
-Mbed OS versioning can be found at [How We Release Arm Mbed OS](https://os-doc-builder.test.mbed.com/docs/development/introduction/how-we-release-arm-mbed-os.html).
+You can find Mbed OS versioning at [How We Release Arm Mbed OS](/docs/development/introduction/how-we-release-arm-mbed-os.html).
 
 ### Pull request categories
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -63,11 +63,7 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 
 #### Release versioning
 
-The Mbed OS version number follows the format MAJOR.FEATURE.PATCH. We use the:
-
-- MAJOR version for incompatible API changes.
-- FEATURE version for adding functionality in backward-compatible manner.
-- PATCH version for backward-compatible bug fixes.
+Mbed OS versioning can be found at [How We Release Arm Mbed OS](https://os-doc-builder.test.mbed.com/docs/development/introduction/how-we-release-arm-mbed-os.html).
 
 ### Pull request categories
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -94,14 +94,13 @@ We consider the following pull request types.
 
 ##### Fix
 
-A bug fix is backward-compatible internal change that fixes incorrect behavior. The fix provides a description what and how it fixes the issue. Tests are included to catch the issue in the future and confirms the correct behavior.
+A bug fix is backward-compatible internal change that fixes incorrect behavior.
 
 Release: patch
 
 ##### Refactor
 
-Refactors are intended for feature releases if they are not fixing specific issue as they 
-can introduce new issues.
+Refactors are intended for feature releases if they are not fixing specific issue as they can introduce new issues.
 
 Release: feature
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -122,7 +122,7 @@ Release: feature
 
 Any change that results in breaking user space. It should have strong justification to be considered. Often the change could be made backward compatible, for example deprecate the old functionality and introduce the new replacement.
 
-Release: feature
+Release: major
 
 ##### Pull request template
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -61,6 +61,14 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 - Avoid merging commmits. (Always rebase when possible.)
 - Pull requests should fix a bug, add a feature or refactor.
 
+#### Mbed OS release versioning
+
+Version number MAJOR.FEATURE.PATCH where:
+
+- MAJOR version for incompatible API changes
+- FEATURE version for adding functionality in backward-compatible manner
+- PATCH version for backward-compatible bug fixes
+
 ### Pull request categories
 
 #### Bug fixes

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -80,7 +80,44 @@ Each feature has a tech lead. This person is responsible for:
 - Rebasing often to track master development.
 - Reviewing any addition to the feature branch (approval required by the feature tech lead or another assigned person).
 
-#### Pull request template
+##### Pull request types
+
+We consider the following pull request types.
+
+##### Fix
+
+A bug fix should be backward-compatible internal change that fixes incorrect behavior. The fix should provide a description what and how it fixes the issue. The test should be included to catch this issue in the future and confirm the correct behavior.
+
+Release: patch version
+
+##### Refactor
+
+Refactors are intended for minor versions if they are not fixing specific issue as they 
+can introduce new issues.
+
+Release: minor version
+
+##### New target
+
+Adding a new target targets the patch release as it updating targets folder implementation.
+
+Release: patch version
+
+##### Feature
+
+New features targets minor releases. It can be integrated only if the feature supports most of the targets (if it requires new target HAL implementation).
+
+Adding a new functionality is considered to be a feature. It does not matter if it is C++ or C.
+
+Release: minor version
+
+##### Breaking change
+
+Any change that results in breaking user space. It should have strong justification to be considered. Often the change could be made backward compatible, for example deprecate the old functionality and introduce the new replacement.
+
+Release: minor version
+
+##### Pull request template
 
 Below is a good example of a pull request:
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -88,34 +88,34 @@ We consider the following pull request types.
 
 A bug fix should be backward-compatible internal change that fixes incorrect behavior. The fix should provide a description what and how it fixes the issue. The test should be included to catch this issue in the future and confirm the correct behavior.
 
-Release: patch version
+Release: patch
 
 ##### Refactor
 
-Refactors are intended for minor versions if they are not fixing specific issue as they 
+Refactors are intended for feature releases if they are not fixing specific issue as they 
 can introduce new issues.
 
-Release: minor version
+Release: feature
 
 ##### New target
 
 Adding a new target targets the patch release as it updating targets folder implementation.
 
-Release: patch version
+Release: patch
 
 ##### Feature
 
-New features targets minor releases. It can be integrated only if the feature supports most of the targets (if it requires new target HAL implementation).
+New features targets feature releases. It can be integrated only if the feature supports most of the targets (if it requires new target HAL implementation).
 
 Adding a new functionality is considered to be a feature. It does not matter if it is C++ or C.
 
-Release: minor version
+Release: feature
 
 ##### Breaking change
 
 Any change that results in breaking user space. It should have strong justification to be considered. Often the change could be made backward compatible, for example deprecate the old functionality and introduce the new replacement.
 
-Release: minor version
+Release: feature
 
 ##### Pull request template
 


### PR DESCRIPTION
Every PR type should be clear to a user.
It is a user responsibility to specify PR type and accept the versioning based on it.

Fixes #429

Proposal to define PR types. I would like to reference this in every pull request so all of us are aware of the responsibility to select the proper type and the release label selection based on that.

Needs more work to be more clear and specify more details, expecting lot of comments 🔥 

@sg- @cmonr @adbridge @theotherjimmy @kjbracey-arm Please review