### PR TITLE
EMAC API reference

### DIFF
--- a/docs/reference/api/connectivity/drivers/EMAC.md
+++ b/docs/reference/api/connectivity/drivers/EMAC.md
@@ -19,20 +19,20 @@ The EMAC driver class is instantiated during the creation of the network interfa
 
 Steps that the network stack uses to power the EMAC driver:
 
-1. The EMAC memory manager class reference is configured for the driver by the network stack.
-1. Network stack sets the link input and state callbacks.
-1. Network stack calls driver's power up function.
-1. Network stack reads MTU and hardware MAC address sizes from the driver.
-1. Hardware MAC address is queried from the driver by network stack. Driver is allowed to respond a failure.
-1. Hardware MAC address is written to driver from network stack.
-    1. If the driver does not provide address on the read call, the network stack chooses the address from the central system configuration and writes that to driver.
+1. The network stack configures the EMAC memory manager class reference for the driver.
+1. The network stack sets the link input and state callbacks.
+1. The network stack calls the driver's power up function.
+1. The network stack reads the MTU and hardware MAC address sizes from the driver.
+1. The network stack queries the hardware MAC address from the driver. The driver is allowed to respond a failure.
+1. The hardware MAC address is written to the driver from the network stack.
+    1. If the driver does not provide an address on the read call, the network stack chooses the address from the central system configuration and writes that to driver.
 
 **Optional steps:**
 
-1. Network stack might query interface name from the driver.
-1. Network stack might configure multicast filtering.
+1. The network stack might query the interface name from the driver.
+1. The network stack might configure multicast filtering.
     1. The driver can either support multicast filtering or provide all frames.
-1. Network stack might query for the memory buffer align preference from the driver.
+1. The network stack might query for the memory buffer align preference from the driver.
     1. The network stack is not required to use the alignment for the memory buffers on link out.
 
 ### EMAC class reference

--- a/docs/reference/api/connectivity/drivers/EMAC.md
+++ b/docs/reference/api/connectivity/drivers/EMAC.md
@@ -1,10 +1,17 @@
 ## EMAC
 
-The Ethernet MAC device driver class provides an interface for a network stack to control the Etherner driver. 
+The Ethernet MAC device driver class provides an interface for a network stack to control the Etherner driver.
 
 ### Default driver
 
-If your EMAC driver is the default for the target, define the static get default instance function to return an instance of your EMAC.
+If your EMAC driver is the default for the target, you should provide implementation of the `EMAC::get_default_instance()`
+
+```
+static EMAC EMAC::get_default_instance() {
+    static MyEMACdriver driver_instance;
+    return driver_instance;
+}
+```
 
 ### Usage
 
@@ -12,34 +19,27 @@ The EMAC driver class is instantiated during the creation of the network interfa
 
 Steps that the network stack uses to power the EMAC driver:
 
-1. The EMAC memory manager class reference is configured to the driver. 
-1. The link input and state callbacks are set.
-1. The driver powers up.
-1. MTU and hardware address sizes are read from the driver.
-1. Hardware address is read from the driver.
-1. Hardware address is written to driver.
+1. The EMAC memory manager class reference is configured for the driver by the network stack.
+1. Network stack sets the link input and state callbacks.
+1. Network stack calls driver's power up function.
+1. Network stack reads MTU and hardware MAC address sizes from the driver.
+1. Hardware MAC address is queried from the driver by network stack. Driver is allowed to respond a failure.
+1. Hardware MAC address is written to driver from network stack.
     1. If the driver does not provide address on the read call, the network stack chooses the address from the central system configuration and writes that to driver.
 
-Optional steps:
+**Optional steps:**
 
-1. Interface name is read from the driver.
-1. Multicast filtering is configured.
+1. Network stack might query interface name from the driver.
+1. Network stack might configure multicast filtering.
     1. The driver can either support multicast filtering or provide all frames.
-1. The memory buffer align preference is read from the driver.
-    1. The network stack may or may not use the alignment for the memory buffers on link out.
+1. Network stack might query for the memory buffer align preference from the driver.
+    1. The network stack is not required to use the alignment for the memory buffers on link out.
 
 ### EMAC class reference
 
-TBD:
-
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emac.html)
-
-### EMAC example
-
-TBD: Add example here from teams repo.
 
 ### Related content
 
-TBD:
-
-- [EMAC memory manager](/docs/development/reference/contributing/connectivity/EMACMemoryManager.html)
+- [EMAC memory manager](emac-memory-manager.html)
+- [Ethernet MAC drivers porting](ethernet-port.html) guide.

--- a/docs/reference/api/connectivity/drivers/EMAC.md
+++ b/docs/reference/api/connectivity/drivers/EMAC.md
@@ -1,0 +1,41 @@
+## EMAC
+
+The Ethernet MAC device driver class provides interface for a network stack to control the Etherner driver. 
+
+### EMAC class reference
+
+TBD:
+
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emac.html)
+
+### Default driver
+
+If your EMAC driver is the default for the target, you should define the static get default instance function to return an instance of your EMAC.
+
+### Usage
+
+EMAC driver class is instantiated during the creation of the network interface. When the network interface is brought up, network stack powers up the EMAC driver.
+
+Steps that the network stack uses to power up the EMAC driver:
+
+1. EMAC memory manager class reference is configured to the driver. 
+1. Link input and state callbacks are set.
+1. Driver is powered up.
+1. MTU and hardware address sizes are read from the driver.
+1. Hardware address is read from the driver.
+1. Hardware address is written to driver.
+    1. If the driver does not provide address on the read call, the network stack chooses the address from the central system configuration and writes that to driver. 
+
+Optional steps:
+
+1. Interface name is read from the driver.
+1. Multicast filtering is configured.
+    1. The driver can either support multicast filtering or provide all frames.
+1. Memory buffer align preference is read from the driver.
+    1. Network stack may or may not use the alignment for the memory buffers on link out.
+
+### Related content
+
+TBD:
+
+- [EMAC memory manager](/docs/development/reference/contributing/connectivity/EMACMemoryManager.html)

--- a/docs/reference/api/connectivity/drivers/EMAC.md
+++ b/docs/reference/api/connectivity/drivers/EMAC.md
@@ -1,6 +1,32 @@
 ## EMAC
 
-The Ethernet MAC device driver class provides interface for a network stack to control the Etherner driver. 
+The Ethernet MAC device driver class provides an interface for a network stack to control the Etherner driver. 
+
+### Default driver
+
+If your EMAC driver is the default for the target, define the static get default instance function to return an instance of your EMAC.
+
+### Usage
+
+The EMAC driver class is instantiated during the creation of the network interface. When the network interface is brought up, the network stack powers the EMAC driver.
+
+Steps that the network stack uses to power the EMAC driver:
+
+1. The EMAC memory manager class reference is configured to the driver. 
+1. The link input and state callbacks are set.
+1. The driver powers up.
+1. MTU and hardware address sizes are read from the driver.
+1. Hardware address is read from the driver.
+1. Hardware address is written to driver.
+    1. If the driver does not provide address on the read call, the network stack chooses the address from the central system configuration and writes that to driver.
+
+Optional steps:
+
+1. Interface name is read from the driver.
+1. Multicast filtering is configured.
+    1. The driver can either support multicast filtering or provide all frames.
+1. The memory buffer align preference is read from the driver.
+    1. The network stack may or may not use the alignment for the memory buffers on link out.
 
 ### EMAC class reference
 
@@ -8,31 +34,9 @@ TBD:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emac.html)
 
-### Default driver
+### EMAC example
 
-If your EMAC driver is the default for the target, you should define the static get default instance function to return an instance of your EMAC.
-
-### Usage
-
-EMAC driver class is instantiated during the creation of the network interface. When the network interface is brought up, network stack powers up the EMAC driver.
-
-Steps that the network stack uses to power up the EMAC driver:
-
-1. EMAC memory manager class reference is configured to the driver. 
-1. Link input and state callbacks are set.
-1. Driver is powered up.
-1. MTU and hardware address sizes are read from the driver.
-1. Hardware address is read from the driver.
-1. Hardware address is written to driver.
-    1. If the driver does not provide address on the read call, the network stack chooses the address from the central system configuration and writes that to driver. 
-
-Optional steps:
-
-1. Interface name is read from the driver.
-1. Multicast filtering is configured.
-    1. The driver can either support multicast filtering or provide all frames.
-1. Memory buffer align preference is read from the driver.
-    1. Network stack may or may not use the alignment for the memory buffers on link out.
+TBD: Add example here from teams repo.
 
 ### Related content
 

--- a/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
+++ b/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
@@ -1,16 +1,16 @@
 ## EMAC memory manager
 
-The Ethernet MAC memory manager class provides abstracted memory interface toward memory modules used in different network stacks. The EMAC device driver uses the memory interface to handle memory related operations, such as allocation, free and data manipulation. This memory manager is used by [EMAC](emac.html) drivers to reserve space for network packets.
+The Ethernet MAC memory manager class provides abstracted memory interface toward memory modules used in different network stacks. The EMAC device driver uses the memory interface to handle memory related operations, such as allocation, free and data manipulation. The [EMAC](emac.html) drivers use this memory manager to reserve space for network packets.
 
 Memory buffer chains store the data on the memory interface. The data passed in either direction either may be contiguous (a single-buffer chain) or may consist of multiple buffers. You can chain the buffers using a singly linked list.
 
 ### Usage
 
-EMAC driver can allocate memory either from a memory pool or from the heap (contiguous memory). By preference, link input memory should be allocated from the pool, but if contiguous memory is required by the hardware, it can be allocated from the heap.
+The EMAC driver can allocate memory either from a memory pool or from the heap (contiguous memory). By preference, link input memory should be allocated from the pool, but if contiguous memory is required by the hardware, it can be allocated from the heap.
 
-The driver can express alignment preferences for buffers sent to it, but the network stack is not required to meet these preferences. This means that the drivers relying on alignment needs to check the buffer address and may need to copy the output data into an aligned (or contiguous) buffers when its requirements are not met.
+The driver can express alignment preferences for buffers sent to it, but the network stack is not required to meet these preferences. This means that the drivers relying on alignment need to check the buffer address and may need to copy the output data into an aligned (or contiguous) buffer when its requirements are not met.
 
-On link output to EMAC driver, buffer chain ownership is given to the driver from network stack. Driver must free the buffer after it is no longer used.
+On link output to the EMAC driver, buffer chain ownership is given to the driver from network stack. The driver must free the buffer after it is no longer used.
 
 On link input to the network stack, buffer chain ownership is given to the stack from driver. Stack frees the buffer after it no longer uses it.
 

--- a/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
+++ b/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
@@ -1,31 +1,24 @@
 ## EMAC memory manager
 
-The Ethernet MAC memory manager class provides abstracted memory interface toward memory modules used in different network stacks. The EMAC device driver uses the memory interface to handle memory related operations, such as allocation, free and data manipulation.
+The Ethernet MAC memory manager class provides abstracted memory interface toward memory modules used in different network stacks. The EMAC device driver uses the memory interface to handle memory related operations, such as allocation, free and data manipulation. This memory manager is used by [EMAC](emac.html) drivers to reserve space for network packets.
 
 Memory buffer chains store the data on the memory interface. The data passed in either direction either may be contiguous (a single-buffer chain) or may consist of multiple buffers. You can chain the buffers using a singly linked list.
 
 ### Usage
 
-On link output to EMAC driver, buffer chain ownership is given to the driver. Driver must free the buffer after it is no longer used. The driver can express alignment preferences for buffers sent to it, but the network stack is not required to meet these preferences. This means that the drivers relying on alignment, may need to copy the output data into an aligned (or contiguous) buffers.
+EMAC driver can allocate memory either from a memory pool or from the heap (contiguous memory). By preference, link input memory should be allocated from the pool, but if contiguous memory is required by the hardware, it can be allocated from the heap.
 
-EMAC driver can allocate memory either from a memory pool or from the heap (contiguous memory). By preference, link input memory should be allocated from the pool, but if contiguous memory is required it can be allocated from the heap. 
+The driver can express alignment preferences for buffers sent to it, but the network stack is not required to meet these preferences. This means that the drivers relying on alignment needs to check the buffer address and may need to copy the output data into an aligned (or contiguous) buffers when its requirements are not met.
 
-On link input to the network stack, buffer chain ownership is given to the stack. Stack frees the buffer after it no longer uses it.
+On link output to EMAC driver, buffer chain ownership is given to the driver from network stack. Driver must free the buffer after it is no longer used.
+
+On link input to the network stack, buffer chain ownership is given to the stack from driver. Stack frees the buffer after it no longer uses it.
 
 ### EMAC memory manager class reference
 
-TBD:
-
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emacmemorymanager.html)
-
-### EMAC memory manager example
-
-TBD:
-
-Add link to example in teams repo here.
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emac_memory_manager.html)
 
 ### Related content
 
-TBD:
-
-- [EMAC](/docs/development/reference/contributing/connectivity/EMAC.html)
+- [EMAC driver](EMAC.html) API
+- [Ethernet MAC drivers porting](ethernet-port.html) guide.

--- a/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
+++ b/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
@@ -1,14 +1,8 @@
 ## EMAC memory manager
 
-The Ethernet MAC memory manager class provides abstracted memory interface towards memory modules used in different network stacks. EMAC device driver uses the memory interface to handle memory related operations like allocation, free and data manipulation.
+The Ethernet MAC memory manager class provides abstracted memory interface toward memory modules used in different network stacks. The EMAC device driver uses the memory interface to handle memory related operations, such as allocation, free and data manipulation.
 
-The data on the memory interface is stored into memory buffer chains. The data passed in either direction may be either contiguous (a single-buffer chain) or may consist of multiple buffers. Chaining of the buffers is made using singly-linked list. 
-
-### EMAC memory manager class reference
-
-TBD:
-
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emacmemorymanager.html)
+Memory buffer chains store the data on the memory interface. The data passed in either direction either may be contiguous (a single-buffer chain) or may consist of multiple buffers. You can chain the buffers using a singly linked list.
 
 ### Usage
 
@@ -17,6 +11,18 @@ On link output to EMAC driver, buffer chain ownership is given to the driver. Dr
 EMAC driver can allocate memory either from a memory pool or from the heap (contiguous memory). By preference, link input memory should be allocated from the pool, but if contiguous memory is required it can be allocated from the heap. 
 
 On link input to the network stack, buffer chain ownership is given to the stack. Stack frees the buffer after it no longer uses it.
+
+### EMAC memory manager class reference
+
+TBD:
+
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emacmemorymanager.html)
+
+### EMAC memory manager example
+
+TBD:
+
+Add link to example in teams repo here.
 
 ### Related content
 

--- a/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
+++ b/docs/reference/api/connectivity/drivers/EMACMemoryManager.md
@@ -1,0 +1,25 @@
+## EMAC memory manager
+
+The Ethernet MAC memory manager class provides abstracted memory interface towards memory modules used in different network stacks. EMAC device driver uses the memory interface to handle memory related operations like allocation, free and data manipulation.
+
+The data on the memory interface is stored into memory buffer chains. The data passed in either direction may be either contiguous (a single-buffer chain) or may consist of multiple buffers. Chaining of the buffers is made using singly-linked list. 
+
+### EMAC memory manager class reference
+
+TBD:
+
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_emacmemorymanager.html)
+
+### Usage
+
+On link output to EMAC driver, buffer chain ownership is given to the driver. Driver must free the buffer after it is no longer used. The driver can express alignment preferences for buffers sent to it, but the network stack is not required to meet these preferences. This means that the drivers relying on alignment, may need to copy the output data into an aligned (or contiguous) buffers.
+
+EMAC driver can allocate memory either from a memory pool or from the heap (contiguous memory). By preference, link input memory should be allocated from the pool, but if contiguous memory is required it can be allocated from the heap. 
+
+On link input to the network stack, buffer chain ownership is given to the stack. Stack frees the buffer after it no longer uses it.
+
+### Related content
+
+TBD:
+
+- [EMAC](/docs/development/reference/contributing/connectivity/EMAC.html)


### PR DESCRIPTION
Added EMAC and EMAC Memory Manager API descriptions under new "\reference\api\connectivity\drivers" directory. 

Please review @SeppoTakalo @AnotherButler 

## NOTE: DO NOT MERGE TO 5.8. THIS IS FOR 5.9 ONLY