### PR TITLE
Refactor Socket API links.

### DIFF
--- a/docs/reference/api/api.md
+++ b/docs/reference/api/api.md
@@ -5,7 +5,8 @@ The [APIs](/docs/development/introduction/glossary.html) in this document are or
 - [Platform](/docs/development/reference/platform.html): platform modules that provide consistent user experience.
 - [Drivers](/docs/development/reference/drivers.html): analog and digital input and outputs and digital interfaces.
 - [RTOS](/docs/development/reference/rtos.html): handling tasks and events in Mbed OS.
-- [Network Socket](/docs/development/reference/network-socket.html): network sockets, Ethernet, Wi-Fi, cellular and mesh networking.
+- [Socket API](socket-api.html): network socket API for TCP/IP.
+- [Network Interfaces](network-interfaces.html): Network interfaces, Ethernet, Wifi, Cellular & Mesh.
 - [Bluetooth](/docs/development/reference/bluetooth.html): bluetooth low energy.
 - [LoRaWAN](/docs/development/reference/lorawan.html): low power wide area network.
 - [Security](/docs/development/reference/security.html): working with Arm Mbed uVisor and Arm Mbed TLS in the context of Mbed OS.

--- a/docs/reference/api/connectivity/networksocket/EthInterface.md
+++ b/docs/reference/api/connectivity/networksocket/EthInterface.md
@@ -21,7 +21,7 @@ Then, if the default configuration is enough, bring up the interface:
 nsapi_error_t status = eth.connect();
 ```
 
-Now, the interface is ready to be used for [network sockets](/docs/development/reference/network-socket.html).
+Now, the interface is ready to be used for [network sockets](socket-api.html).
 
 ```cpp
 // Open a TCP socket

--- a/docs/reference/api/connectivity/networksocket/MeshInterface.md
+++ b/docs/reference/api/connectivity/networksocket/MeshInterface.md
@@ -13,7 +13,7 @@ Mbed OS provides two types of IPv6 based mesh networks:
 
 Nanostack is the networking stack that provides both of these protocols. For more information on the stack internals, please refer to the [Nanostack documentation](/docs/v5.7/tutorials/mesh.html#nanostack). Application developers use Nanostack through the Mbed Mesh API.
 
-The application can use the `LoWPANNDInterface` or `ThreadInterface` object for connecting to the mesh network. When successfully connected, the application can use the Mbed C++ socket APIs to create a socket to start communication with a remote peer.
+The application can use the `LoWPANNDInterface` or `ThreadInterface` object for connecting to the mesh network. When successfully connected, the application can use the Mbed [C++ socket APIs](socket-api.html) to create a socket to start communication with a remote peer.
 
 ##### Supported mesh networking modes
 

--- a/docs/reference/api/connectivity/networksocket/networksocket.md
+++ b/docs/reference/api/connectivity/networksocket/networksocket.md
@@ -1,11 +1,11 @@
-## Network socket overview
+<h2 id="socket-api">Network socket overview</h2>
 
 This section covers the Socket APIs in Arm Mbed OS, which are:
 
-- [UDPSocket](/docs/development/reference/udpsocket.html): This class provides the ability to send packets of data over UDP, using the sendto and recvfrom member functions.
-- [TCPSocket](/docs/development/reference/tcpsocket.html): This class provides the ability to send a stream of data over TCP.
-- [TCPServer](/docs/development/reference/tcpserver.html): This class provides the ability to accept incoming TCP connections.
-- [SocketAddress](/docs/development/reference/socketaddress.html): You can use this class to represent the IP address and port pair of a unique network endpoint.
+- [UDPSocket](udpsocket.html): This class provides the ability to send packets of data over UDP, using the sendto and recvfrom member functions.
+- [TCPSocket](tcpsocket.html): This class provides the ability to send a stream of data over TCP.
+- [TCPServer](tcpserver.html): This class provides the ability to accept incoming TCP connections.
+- [SocketAddress](socketaddress.html): You can use this class to represent the IP address and port pair of a unique network endpoint.
 
 Continue reading for detailed reference material about some of these APIs.
 
@@ -15,7 +15,7 @@ The network-socket API provides a common interface for using sockets on network 
 
 ##### Network errors
 
-The convention of the network-socket API is for functions to return negative error codes to indicate failure. On success, a function may return zero or a non-negative integer to indicate the size of a transaction. On failure, a function must return a negative integer, which should be one of the error codes in the `nsapi_error_t` [enum](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba):
+The convention of the network-socket API is for functions to return negative error codes to indicate failure. On success, a function may return zero or a non-negative integer to indicate the size of a transaction. On failure, a function must return a negative integer, which should be one of the error codes in the `nsapi_error_t` [enum](/docs/development/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba):
 
 ``` cpp
 /** Enum of standardized error codes

--- a/docs/reference/technology/connectivity/networking.md
+++ b/docs/reference/technology/connectivity/networking.md
@@ -12,7 +12,7 @@ The Socket API is the common API among all IP connectivity methods. All network 
 
 In the OSI model, the Socket API relates to layer 4, the Transport layer. In Mbed OS, the Socket API supports both TCP and UDP protocols.
 
-Refer to [Socket API](network-socket.html) reference for usage instructions.
+Refer to [Socket API](socket-api.html) reference for usage instructions.
 
 ### IP stacks
 

--- a/docs/reference/technology/mesh/thread_intro.md
+++ b/docs/reference/technology/mesh/thread_intro.md
@@ -34,7 +34,7 @@ The key elements of Mbed OS are:
 Mbed Thread is implemented in the Nanostack library, which also supports the 6LoWPAN protocol. In Mbed OS, the Thread stack runs in its own RTOS thread using an internal event scheduler. Mbed OS provides the [Mesh C++ API](/docs/development/reference/mesh-api.html) for building Thread applications.
 
 - To connect to the Thread network, use the [Thread interface API](https://github.com/ARMmbed/mbed-os/blob/master/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h).
-- For the socket communication over the Thread network, use the [Mbed sockets API](/docs/development/reference/network-socket.html).
+- For the socket communication over the Thread network, use the [Mbed sockets API](socket-api.html).
 
 Nanostack provides a set of C API headers with more functionalities. The [nanostack repository](https://github.com/ARMmbed/mbed-os/tree/master/features/nanostack/FEATURE_NANOSTACK/sal-stack-nanostack/nanostack) has the following header files():
 


### PR DESCRIPTION
+ Use descriptive link ID
+ Use relative links, not absolute. Makes it cleaner.

For future, when I link to Socket API, I want to use link id which is `socket-api.html`, easier to remember, and cleaner.

I believe this is now according to `Publishing guide` -> `Text styling - the technical details`

CC: @AnotherButler Please review
