### PR TITLE
Fix Socket API link by using same ID in the "title" field in docs.json

### DIFF
--- a/docs/reference/api/api.md
+++ b/docs/reference/api/api.md
@@ -5,7 +5,7 @@ The [APIs](/docs/development/introduction/glossary.html) in this document are or
 - [Platform](/docs/development/reference/platform.html): platform modules that provide consistent user experience.
 - [Drivers](/docs/development/reference/drivers.html): analog and digital input and outputs and digital interfaces.
 - [RTOS](/docs/development/reference/rtos.html): handling tasks and events in Mbed OS.
-- [Socket API](socket-api.html): network socket API for TCP/IP.
+- [Socket API](network-socket.html): network socket API for TCP/IP.
 - [Network Interfaces](network-interfaces.html): Network interfaces, Ethernet, Wifi, Cellular & Mesh.
 - [Bluetooth](/docs/development/reference/bluetooth.html): bluetooth low energy.
 - [LoRaWAN](/docs/development/reference/lorawan.html): low power wide area network.

--- a/docs/reference/api/connectivity/networksocket/EthInterface.md
+++ b/docs/reference/api/connectivity/networksocket/EthInterface.md
@@ -21,7 +21,7 @@ Then, if the default configuration is enough, bring up the interface:
 nsapi_error_t status = eth.connect();
 ```
 
-Now, the interface is ready to be used for [network sockets](socket-api.html).
+Now, the interface is ready to be used for [network sockets](network-socket.html).
 
 ```cpp
 // Open a TCP socket

--- a/docs/reference/api/connectivity/networksocket/MeshInterface.md
+++ b/docs/reference/api/connectivity/networksocket/MeshInterface.md
@@ -13,7 +13,7 @@ Mbed OS provides two types of IPv6 based mesh networks:
 
 Nanostack is the networking stack that provides both of these protocols. For more information on the stack internals, please refer to the [Nanostack documentation](/docs/v5.7/tutorials/mesh.html#nanostack). Application developers use Nanostack through the Mbed Mesh API.
 
-The application can use the `LoWPANNDInterface` or `ThreadInterface` object for connecting to the mesh network. When successfully connected, the application can use the Mbed [C++ socket APIs](socket-api.html) to create a socket to start communication with a remote peer.
+The application can use the `LoWPANNDInterface` or `ThreadInterface` object for connecting to the mesh network. When successfully connected, the application can use the Mbed [C++ socket APIs](network-socket.html) to create a socket to start communication with a remote peer.
 
 ##### Supported mesh networking modes
 

--- a/docs/reference/api/connectivity/networksocket/networksocket.md
+++ b/docs/reference/api/connectivity/networksocket/networksocket.md
@@ -1,4 +1,4 @@
-<h2 id="socket-api">Network socket overview</h2>
+<h2 id="network-socket">Network socket overview</h2>
 
 This section covers the Socket APIs in Arm Mbed OS, which are:
 

--- a/docs/reference/technology/connectivity/networking.md
+++ b/docs/reference/technology/connectivity/networking.md
@@ -12,7 +12,7 @@ The Socket API is the common API among all IP connectivity methods. All network 
 
 In the OSI model, the Socket API relates to layer 4, the Transport layer. In Mbed OS, the Socket API supports both TCP and UDP protocols.
 
-Refer to [Socket API](socket-api.html) reference for usage instructions.
+Refer to [Socket API](network-socket.html) reference for usage instructions.
 
 ### IP stacks
 

--- a/docs/reference/technology/mesh/thread_intro.md
+++ b/docs/reference/technology/mesh/thread_intro.md
@@ -34,7 +34,7 @@ The key elements of Mbed OS are:
 Mbed Thread is implemented in the Nanostack library, which also supports the 6LoWPAN protocol. In Mbed OS, the Thread stack runs in its own RTOS thread using an internal event scheduler. Mbed OS provides the [Mesh C++ API](/docs/development/reference/mesh-api.html) for building Thread applications.
 
 - To connect to the Thread network, use the [Thread interface API](https://github.com/ARMmbed/mbed-os/blob/master/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h).
-- For the socket communication over the Thread network, use the [Mbed sockets API](socket-api.html).
+- For the socket communication over the Thread network, use the [Mbed sockets API](network-socket.html).
 
 Nanostack provides a set of C API headers with more functionalities. The [nanostack repository](https://github.com/ARMmbed/mbed-os/tree/master/features/nanostack/FEATURE_NANOSTACK/sal-stack-nanostack/nanostack) has the following header files():
 


### PR DESCRIPTION
* Fix the render engine bug found in https://github.com/ARMmbed/Handbook/pull/497

@iriark01 @AnotherButler Please merge in, so Socket-API links will be fixed.
