### PR TITLE
Specify application header format in manager bl mode

### DIFF
--- a/docs/tools/bootloader.md
+++ b/docs/tools/bootloader.md
@@ -48,49 +48,48 @@ The start address of the current application, as computed above, is available to
 
 You may use this parameter in conjunction with `target.bootloader_img`, `target.header_format`, `target.header_offset` and `target.app_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`. When used with `target.bootloader_img`, that parameter defines the start of the application. Otherwise, the start is the start of ROM.
 
-
 ### `target.header_format`
 
-The `target.header_format` configuration key defines an application header as a list of tuples. Each tuple represents a single element of the header format as a name (a valid C identifier), a type, a subtype and finally a single argument. For example, the const type defines subtypes for common sizes of constants, including the 32be subtype that indicates the constant will be represented as 32 bits big endian. The following is a list of all types and subtypes that the Mbed OS build tools support.
+The `target.header_format` configuration key defines an application header as a list of tuples. Each tuple represents a single element of the header format as a name (a valid C identifier), a type, a subtype and finally a single argument. For example, the const type defines subtypes for common sizes of constants, including the 32be subtype that indicates the constant is represented as 32-bit big endian. The following is a list of all types and subtypes that the Mbed OS build tools support.
 
- * `const` A constant value.
-   * `8be` A value represented as 8 bits.
-   * `16be` A value represented as 16 bits big endian.
-   * `32be` A value represented as 32 bits big endian.
-   * `64be` A value represented as 64 bits big endian.
-   * `8le` A value represented as 8 bits.
-   * `16le` A value represented as 16 bits little endian.
-   * `32le` A value represented as 32 bits little endian.
-   * `64le` A value represented as 64 bits little endian.
+- `const` A constant value.
+    - `8be` A value represented as 8 bits.
+    - `16be` A value represented as 16 bits big endian.
+    - `32be` A value represented as 32 bits big endian.
+    - `64be` A value represented as 64 bits big endian.
+    - `8le` A value represented as 8 bits.
+    - `16le` A value represented as 16 bits little endian.
+    - `32le` A value represented as 32 bits little endian.
+    - `64le` A value represented as 64 bits little endian.
 
- * `timestamp` A time stamp value, in seconds from epoch in the timezone GMT/UTC. The argument to this type is always null.
-    * `64be` A time stamp value truncated to 64 bits big endian.
-    * `64le` A time stamp value truncated to 64 bits ilttle endian.
+- `timestamp` A time stamp value in seconds from epoch in the timezone GMT/UTC. The argument to this type is always null.
+    - `64be` A time stamp value truncated to 64 bits big endian.
+    - `64le` A time stamp value truncated to 64 bits little endian.
 
- * `digest` A digest of an image. All digests are computed in the order they appear. A digest of the header digests the header up to its start address.
-    * `CRCITT32be` A big endian 32bit checksum of an image with an initial value of 0xffffffff, input reversed, and output reflected.
-    * `CRCITT32le` A little endian 32bit checksum of an image with an initial value of 0xffffffff, input reversed, and output reflected.
-    * `SHA256` A SHA-2 using a block-size of 256 bits.
-    * `SHA512` A SHA-2 using a block-size of 512 bits.
+- `digest` A digest of an image. All digests are computed in the order they appear. A digest of the header digests the header up to its start address.
+    - `CRCITT32be` A big endian 32-bit checksum of an image with an initial value of `0xffffffff`, input reversed, and output reflected.
+    - `CRCITT32le` A little endian 32bit checksum of an image with an initial value of `0xffffffff`, input reversed, and output reflected.
+    - `SHA256` A SHA-2 using a block-size of 256 bits.
+    - `SHA512` A SHA-2 using a block-size of 512 bits.
 
- * `size` The size of a list of images, added together.
-    * `32be` A size represented as 32 bits big endian.
-    * `64be` A size represented as 64 bits big endain.
-    * `32le` A size represented as 32 bits little endian.
-    * `64le` A size represented as 64 bits little endain.
+- `size` The size of a list of images, added together.
+    - `32be` A size represented as 32 bits big endian.
+    - `64be` A size represented as 64 bits big endain.
+    - `32le` A size represented as 32 bits little endian.
+    - `64le` A size represented as 64 bits little endain.
 
-Items in the application header are packed starting where the previous field ended; Items in the header are packed using the C "packed" struct semantics. The presence of the `target.header_format` format field defines two macros `MBED_HEADER_START`, which expands to the start address of the firmware header, and `MBED_HEADER_SIZE`, containing the size in bytes of the firmware header.The region following the application header starts at `MBED_HEADER_START + MBED_HEADER_SIZE` rounded up to a multiple of 8 bytes. 
+Items in the application header are packed starting where the previous field ended; items in the header are packed using the C "packed" struct semantics. The presence of the `target.header_format` format field defines two macros `MBED_HEADER_START`, which expands to the start address of the firmware header, and `MBED_HEADER_SIZE`, containing the size in bytes of the firmware header.The region following the application header starts at `MBED_HEADER_START + MBED_HEADER_SIZE` rounded up to a multiple of 8 bytes.
 
 You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_offset` and `target.app_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`. When used with `target.bootloader_img`, that parameter defines the start of the application. Otherwise, the start is the start of ROM.
 
 ### `target.header_offset`
 
-This parameters directly assigns the offset of the beginning of the header section defined in `target.header_format`. This parameter creates space between the boot loader and application header or asserts that the boot loader is at most as big as the specified offset. 
+This parameter directly assigns the offset of the beginning of the header section defined in `target.header_format`. This parameter creates space between the bootloader and application header or asserts that the bootloader is at most as big as the specified offset.
 
-You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_format` and `target.app_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`. 
+You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_format` and `target.app_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`.
 
 ### `target.app_offset`
 
-This parameters directly assigns the offset of the beginning of the application section that follows the header, when defined in `target.header_format`, or the boot loader defined in `target.bootloader_img`. This parameter creates space between the application header and the application.
+This parameter directly assigns the offset of the beginning of the application section that follows the header, when defined in `target.header_format`, or the bootloader defined in `target.bootloader_img`. This parameter creates space between the application header and the application.
 
-You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_format` and `target.header_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`. 
+You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_format` and `target.header_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`.

--- a/docs/tools/bootloader.md
+++ b/docs/tools/bootloader.md
@@ -90,6 +90,6 @@ You may use this parameter in conjunction with `target.bootloader_img`, `target.
 
 ### `target.app_offset`
 
-This parameter directly assigns the offset of the beginning of the application section that follows the header, when defined in `target.header_format`, or the bootloader defined in `target.bootloader_img`. This parameter creates space between the application header and the application.
+This parameter assigns the offset of the beginning of the application section that follows the header. This parameter creates space between the application header and the application.
 
 You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_format` and `target.header_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`.

--- a/docs/tools/bootloader.md
+++ b/docs/tools/bootloader.md
@@ -78,7 +78,7 @@ The `target.header_format` configuration key defines an application header as a 
     - `32le` A size represented as 32 bits little endian.
     - `64le` A size represented as 64 bits little endain.
 
-Items in the application header are packed starting where the previous field ended; items in the header are packed using the C "packed" struct semantics. The presence of the `target.header_format` format field defines two macros `MBED_HEADER_START`, which expands to the start address of the firmware header, and `MBED_HEADER_SIZE`, containing the size in bytes of the firmware header.The region following the application header starts at `MBED_HEADER_START + MBED_HEADER_SIZE` rounded up to a multiple of 8 bytes.
+The Mbed OS tools build items in the application header starting where the previous field ended; the tools build items in the header using the C "packed" struct semantics. The presence of the `target.header_format` format field defines two macros `MBED_HEADER_START`, which expands to the start address of the firmware header, and `MBED_HEADER_SIZE`, containing the size in bytes of the firmware header. The region following the application header starts at `MBED_HEADER_START + MBED_HEADER_SIZE` rounded up to a multiple of 8 bytes.
 
 You may use this parameter in conjunction with `target.bootloader_img`, `target.restrict_size`, `target.header_offset` and `target.app_offset`. It conflicts with `target.mbed_app_start` and `target.mbed_app_size`. When used with `target.bootloader_img`, that parameter defines the start of the application. Otherwise, the start is the start of ROM.
 

--- a/docs/tutorials/bootloader.md
+++ b/docs/tutorials/bootloader.md
@@ -97,7 +97,7 @@ For an example showing how to create an application that uses a bootloader, see 
 
 #### Adding an application header
 
-Taking this one step further, add a metadata header to the bootloader and application so that the bootloader can verify the integrity of the application. Create an `mbed_lib.json` that is shared between the bootloader and application with the following contents.
+Take this one step further, and add a metadata header to the bootloader and application, so the bootloader can verify the integrity of the application. Create an `mbed_lib.json` that the bootloader and application share and that has the following contents.
 
 ```JSON
 {
@@ -117,7 +117,7 @@ Taking this one step further, add a metadata header to the bootloader and applic
 }
 ```
 
-This configuration will add a new region, named header, after the bootloader and before the application header. The ROM of your target now looks as follows:
+This configuration adds a new region, named header, after the bootloader and before the application header. The ROM of your target now looks as follows:
 
 ```
 |-------------------|   APPLICATION_ADDR + APPLICATION_SIZE == End of ROM


### PR DESCRIPTION
This feature is in 5.8.0 onward, and can be merged into the 5.8 documentation