### PR TITLE
Adds Network Status Callback registration page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -424,6 +424,10 @@
                             {
                                 "type": "markdown",
                                 "url": "https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/connectivity/networksocket/MeshInterface.md"
+                            },
+                            {
+                                "type": "markdown",
+                                "url": "https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/connectivity/networksocket/NetworkStatus.md"
                             }
                         ]
                     },

--- a/docs/reference/api/connectivity/networksocket/EthInterface.md
+++ b/docs/reference/api/connectivity/networksocket/EthInterface.md
@@ -53,15 +53,11 @@ Network interface `connect` failure causes:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_eth_interface.html)
 
-### EthInterface examples
+### EthInterface example
 
 Here is an example of an HTTP client program. The program brings up Ethernet as the underlying network interface and uses it to perform an HTTP transaction over a TCPSocket:
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/TCPSocket_Example/)](https://os.mbed.com/teams/mbed_example/code/TCPSocket_Example/file/6b383744246e/main.cpp)
-
-Here is an example showing how to register a status callback that gets triggered when connection state changes. This also works with other network interfaces if support is provided.
-
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/)](https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/file/8a8191e3d305/main.cpp)
 
 ### Related content
 

--- a/docs/reference/api/connectivity/networksocket/NetworkStatus.md
+++ b/docs/reference/api/connectivity/networksocket/NetworkStatus.md
@@ -1,0 +1,76 @@
+<h2 id="network-status">Network status</h2>
+
+Purpose of this interface is to provide a way to inform about connection state changes asynchronously. This is accomplished
+by providing a method to register a callback function to a socket. The callback gets triggered each time the network interface's state changes. 
+
+### Usage
+
+
+Possible network states the callback needs to be able to handle
+ 
+```cpp
+/** Enum of connection status types
+ *
+ *  Valid error codes have negative values.
+ *
+ *  @enum nsapi_connection_status
+ */
+ typedef enum nsapi_connection_status {
+    NSAPI_STATUS_LOCAL_UP           = 0,        /*!< local IP address set */
+    NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
+    NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
+    NSAPI_STATUS_CONNECTING         = 3,        /*!< connecting to network */
+    NSAPI_STATUS_ERROR_UNSUPPORTED  = NSAPI_ERROR_UNSUPPORTED
+} nsapi_connection_status_t;
+```
+
+An interface which is to be monitored - ethernet used here only as an example
+
+```cpp
+EthernetInterface eth;
+```
+
+There is need to provide the callback function itself
+
+```cpp
+void status_callback(nsapi_event_t status, intptr_t param)
+{
+    printf("Connection status changed!\r\n");
+    switch(param) {
+        case NSAPI_STATUS_LOCAL_UP:
+            printf("Local IP address set!\r\n");
+            break;
+        case NSAPI_STATUS_GLOBAL_UP:
+            printf("Global IP address set!\r\n");
+            break;
+        case NSAPI_STATUS_DISCONNECTED:
+            printf("No connection to network!\r\n");
+            break;
+        case NSAPI_STATUS_CONNECTING:
+            printf("Connecting to network!\r\n");
+            break;
+        default:
+            printf("Not supported");
+            break;
+    }
+}
+```
+
+Now, the callback function is to be registered to the interface. The socket needs to be set in
+non-blocking mode for the asynchronous behavior.  
+
+```cpp
+    eth.attach(&status_callback);
+    eth.set_blocking(false);
+```
+
+### Example
+
+How to register a status callback that gets triggered when connection state changes. It depends from a network interface 
+if this functionality is provided.
+
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/)](https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/file/8a8191e3d305/main.cpp)
+
+### Related content
+
+- [Network socket](/docs/development/reference/network-socket.html) API reference overview.

--- a/docs/reference/api/connectivity/networksocket/NetworkStatus.md
+++ b/docs/reference/api/connectivity/networksocket/NetworkStatus.md
@@ -6,21 +6,7 @@ This interface informs you about connection state changes asynchronously. Provid
 
 The callback needs to handle these possible network states:
 
-```cpp
-/** Enum of connection status types
- *
- *  Valid error codes have negative values.
- *
- *  @enum nsapi_connection_status
- */
- typedef enum nsapi_connection_status {
-    NSAPI_STATUS_LOCAL_UP,            /*!< local IP address set */
-    NSAPI_STATUS_GLOBAL_UP,           /*!< global IP address set */
-    NSAPI_STATUS_DISCONNECTED,        /*!< no connection to network */
-    NSAPI_STATUS_CONNECTING,          /*!< connecting to network */
-    NSAPI_STATUS_ERROR_UNSUPPORTED  = NSAPI_ERROR_UNSUPPORTED
-} nsapi_connection_status_t;
-```
+[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__netsocket.html#ga61fab8ca5ae5d56fb51a86dcd36f56ea)
 
 This API requires an interface to be monitored. For example, Ethernet:
 

--- a/docs/reference/api/connectivity/networksocket/NetworkStatus.md
+++ b/docs/reference/api/connectivity/networksocket/NetworkStatus.md
@@ -1,13 +1,13 @@
 <h2 id="network-status">Network status</h2>
 
 Purpose of this interface is to provide a way to inform about connection state changes asynchronously. This is accomplished
-by providing a method to register a callback function to a socket. The callback gets triggered each time the network interface's state changes. 
+by providing a method to register a callback function to a socket. The callback gets triggered each time the network interface's state changes.
 
 ### Usage
 
 
 Possible network states the callback needs to be able to handle
- 
+
 ```cpp
 /** Enum of connection status types
  *
@@ -16,10 +16,10 @@ Possible network states the callback needs to be able to handle
  *  @enum nsapi_connection_status
  */
  typedef enum nsapi_connection_status {
-    NSAPI_STATUS_LOCAL_UP           = 0,        /*!< local IP address set */
-    NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
-    NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
-    NSAPI_STATUS_CONNECTING         = 3,        /*!< connecting to network */
+    NSAPI_STATUS_LOCAL_UP,            /*!< local IP address set */
+    NSAPI_STATUS_GLOBAL_UP,           /*!< global IP address set */
+    NSAPI_STATUS_DISCONNECTED,        /*!< no connection to network */
+    NSAPI_STATUS_CONNECTING,          /*!< connecting to network */
     NSAPI_STATUS_ERROR_UNSUPPORTED  = NSAPI_ERROR_UNSUPPORTED
 } nsapi_connection_status_t;
 ```
@@ -56,17 +56,26 @@ void status_callback(nsapi_event_t status, intptr_t param)
 }
 ```
 
-Now, the callback function is to be registered to the interface. The socket needs to be set in
-non-blocking mode for the asynchronous behavior.  
+Now, the callback function is to be registered to the interface.
 
 ```cpp
     eth.attach(&status_callback);
-    eth.set_blocking(false);
 ```
+
+This allows application to monitor if network interface gets disconnected.
+
+Optionally, application might want to set the `connect()` method to non-blocking mode and wait until connectivity is fully established.
+
+```cpp
+    eth.set_blocking(false);
+    eth.connect();              // Return immediately
+```
+
+By default, the `connect()` call blocks until `NSAPI_STATUS_GLOBAL_UP` state is reached. Some applications might require only link-ocal connectivity and therefore do not need to block that long. In those case monitoring the state changes is the preferred behaviour.
 
 ### Example
 
-How to register a status callback that gets triggered when connection state changes. It depends from a network interface 
+How to register a status callback that gets triggered when connection state changes. It depends from a network interface
 if this functionality is provided.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/)](https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/file/8a8191e3d305/main.cpp)

--- a/docs/reference/api/connectivity/networksocket/NetworkStatus.md
+++ b/docs/reference/api/connectivity/networksocket/NetworkStatus.md
@@ -1,12 +1,10 @@
 <h2 id="network-status">Network status</h2>
 
-Purpose of this interface is to provide a way to inform about connection state changes asynchronously. This is accomplished
-by providing a method to register a callback function to a socket. The callback gets triggered each time the network interface's state changes.
+This interface informs you about connection state changes asynchronously. Providing a method to register a callback function to a socket accomplishes this. Each time the network interface's state changes, it triggers the callback.
 
-### Usage
+#### Usage
 
-
-Possible network states the callback needs to be able to handle
+The callback needs to handle these possible network states:
 
 ```cpp
 /** Enum of connection status types
@@ -24,13 +22,13 @@ Possible network states the callback needs to be able to handle
 } nsapi_connection_status_t;
 ```
 
-An interface which is to be monitored - ethernet used here only as an example
+This API requires an interface to be monitored. For example, Ethernet:
 
 ```cpp
 EthernetInterface eth;
 ```
 
-There is need to provide the callback function itself
+You need to provide the callback function, itself:
 
 ```cpp
 void status_callback(nsapi_event_t status, intptr_t param)
@@ -56,27 +54,26 @@ void status_callback(nsapi_event_t status, intptr_t param)
 }
 ```
 
-Now, the callback function is to be registered to the interface.
+Now, the callback function is registered to the interface.
 
 ```cpp
     eth.attach(&status_callback);
 ```
 
-This allows application to monitor if network interface gets disconnected.
+This allows the application to monitor if network interface gets disconnected.
 
-Optionally, application might want to set the `connect()` method to non-blocking mode and wait until connectivity is fully established.
+Optionally, the application might want to set the `connect()` method to nonblocking mode and wait until connectivity is fully established.
 
 ```cpp
     eth.set_blocking(false);
     eth.connect();              // Return immediately
 ```
 
-By default, the `connect()` call blocks until `NSAPI_STATUS_GLOBAL_UP` state is reached. Some applications might require only link-ocal connectivity and therefore do not need to block that long. In those case monitoring the state changes is the preferred behaviour.
+By default, the `connect()` call blocks until `NSAPI_STATUS_GLOBAL_UP` state is reached. Some applications might require only link-ocal connectivity and therefore do not need to block that long. In those case monitoring the state changes is the preferred behavior.
 
 ### Example
 
-How to register a status callback that gets triggered when connection state changes. It depends from a network interface
-if this functionality is provided.
+Registering a status callback that connection state changes trigger depends on whether the network interface provides this functionality.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/)](https://os.mbed.com/teams/mbed_example/code/TCPSocket_ConnStateCb_Example/file/8a8191e3d305/main.cpp)
 

--- a/docs/reference/api/connectivity/networksocket/networkinterface.md
+++ b/docs/reference/api/connectivity/networksocket/networkinterface.md
@@ -11,3 +11,8 @@ Existing network interfaces:
 - [Wi-Fi](/docs/development/reference/wi-fi.html): API for connecting to the internet with a Wi-Fi device.
 - [Cellular](/docs/development/reference/cellular-api.html): API for connecting to the internet using a cellular device.
 - [Mesh networking interface](/docs/development/reference/mesh-api.html): Mbed OS provides two kinds of IPv6-based mesh networks - 6LoWPAN_ND and Thread.
+
+Optional functionality
+
+
+- [Network status](network-status.html): API for registering a network status listener

--- a/docs/reference/api/connectivity/networksocket/networkinterface.md
+++ b/docs/reference/api/connectivity/networksocket/networkinterface.md
@@ -6,13 +6,11 @@ Network interface is also the controlling API for application to specify network
 
 Existing network interfaces:
 
-
 - [Ethernet](/docs/development/reference/ethernet.html): API for connecting to the internet over an Ethernet connection.
 - [Wi-Fi](/docs/development/reference/wi-fi.html): API for connecting to the internet with a Wi-Fi device.
 - [Cellular](/docs/development/reference/cellular-api.html): API for connecting to the internet using a cellular device.
 - [Mesh networking interface](/docs/development/reference/mesh-api.html): Mbed OS provides two kinds of IPv6-based mesh networks - 6LoWPAN_ND and Thread.
 
-Optional functionality
-
+Optional functionality:
 
 - [Network status](network-status.html): API for monitoring network status changes.

--- a/docs/reference/api/connectivity/networksocket/networkinterface.md
+++ b/docs/reference/api/connectivity/networksocket/networkinterface.md
@@ -15,4 +15,4 @@ Existing network interfaces:
 Optional functionality
 
 
-- [Network status](network-status.html): API for registering a network status listener
+- [Network status](network-status.html): API for monitoring network status changes.

--- a/docs/reference/api/connectivity/networksocket/networksocket.md
+++ b/docs/reference/api/connectivity/networksocket/networksocket.md
@@ -51,6 +51,7 @@ The network socket API provides a common interface for using sockets on network 
 - [TCPSocket](tcpsocket.html): This class provides the ability to send a stream of data over TCP.
 - [TCPServer](tcpserver.html): This class provides the ability to accept incoming TCP connections.
 - [SocketAddress](socketaddress.html): You can use this class to represent the IP address and port pair of a unique network endpoint.
+- [NetworkStatus](network-status.html): You can use this API to get information about connection state changes
 
 ### Network errors
 

--- a/docs/reference/api/connectivity/networksocket/networksocket.md
+++ b/docs/reference/api/connectivity/networksocket/networksocket.md
@@ -51,7 +51,7 @@ The network socket API provides a common interface for using sockets on network 
 - [TCPSocket](tcpsocket.html): This class provides the ability to send a stream of data over TCP.
 - [TCPServer](tcpserver.html): This class provides the ability to accept incoming TCP connections.
 - [SocketAddress](socketaddress.html): You can use this class to represent the IP address and port pair of a unique network endpoint.
-- [NetworkStatus](network-status.html): You can use this API to get information about connection state changes
+- [Network status](network-status.html): API for monitoring network status changes.
 
 ### Network errors
 


### PR DESCRIPTION
Replaces already existing documentation about the subject. Explains
a bit further what is required from the application POV. @SeppoTakalo, @jarlamsa have a look and please let me know how to improve it. @AnotherButler Is it somehow possible to render the documentation(this PR) so I would see that all the links are working etc?