### PR TITLE
Remove UVISOR references from Handbook

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -439,12 +439,7 @@
                         "sources": [{
                                 "type": "markdown",
                                 "url": "https://github.com/ARMmbed/Handbook/blob/new_engine/docs/reference/api/security/TLS.md"
-                            },
-                            {
-                                "type": "markdown",
-                                "url": "https://github.com/ARMmbed/uvisor/blob/master/docs/lib/INTRO.md"
-                            }
-                        ]
+                            }]
                     },
                     {
                         "title": "Storage",

--- a/docs/introduction/examples.md
+++ b/docs/introduction/examples.md
@@ -39,12 +39,6 @@ A few micro:bit How To videos:
 - [Hashing](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-hashing/): performs hashing of a buffer with SHA-256 using various APIs. It serves as a tutorial for the basic hashing APIs of Mbed TLS.
 - [TLS client](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client/): downloads a file from an HTTPS server (os.mbed.com) and looks for a specific string in that file.
 
-##### Arm Mbed uVisor
-
-- [Threaded Blinky with uVisor](https://github.com/ARMmbed/mbed-os-example-uvisor-thread): an example threaded application with uVisor security.
-- [IRQ Blinky uVisor](https://github.com/ARMmbed/mbed-os-example-uvisor): an example threaded application with uVisor security and IRQ support.
-- [Threaded REPC with uVisor](https://github.com/ARMmbed/mbed-os-example-uvisor-number-store): using uVisor APIs to build a box that stores a number.
-
 These examples work on the K64F and the GNU Arm Embedded toolchain only.
 
 #### Core features

--- a/docs/introduction/terms.md
+++ b/docs/introduction/terms.md
@@ -16,8 +16,6 @@
 
 **Arm Mbed TLS** - A [comprehensive SSL/TLS solution](/docs/development/reference/tls.html) that makes it easy for developers to include cryptographic and SSL/TLS capabilities in their software and embedded products. As an SSL library, it provides an intuitive API, readable source code and a minimal and highly configurable code footprint.
 
-**Arm Mbed uVisor** - A self-contained [software hypervisor](/docs/development/reference/tls.html#uVisor) that creates independent secure domains on ARM Cortex-M3 and M4 micro-controllers.
-
 ### B
 
 **Bit** - A basic unit of digital information that can be one of two values: `0` (`false`) or `1` (`true`).

--- a/docs/reference/api/api.md
+++ b/docs/reference/api/api.md
@@ -8,7 +8,7 @@ The [APIs](/docs/development/introduction/glossary.html) in this document are or
 - [Network Socket](/docs/development/reference/network-socket.html): network sockets, Ethernet, Wi-Fi, cellular and mesh networking.
 - [Bluetooth](/docs/development/reference/bluetooth.html): bluetooth low energy.
 - [LoRaWAN](/docs/development/reference/lorawan.html): low power wide area network.
-- [Security](/docs/development/reference/security.html): working with Arm Mbed uVisor and Arm Mbed TLS in the context of Mbed OS.
+- [Security](/docs/development/reference/security.html): working with Arm Mbed TLS in the context of Mbed OS.
 - [Storage](/docs/development/reference/storage.html): working with the file system.
 
 We also provide guidelines for [contributing to Mbed OS](/docs/development/reference/contributing.html).

--- a/docs/reference/api/security/security.md
+++ b/docs/reference/api/security/security.md
@@ -1,11 +1,11 @@
 ## Security overview
 
-Security on Arm Mbed OS is divided into two parts:
+Security on Arm Mbed OS is covered by the Mbed TLS module:
 
-- [Connection security through Arm Mbed TLS](/docs/development/reference/tls.html).
-- [Device security through Arm Mbed uVisor](/docs/development/reference/uvisor.html).
+[Connection security through Arm Mbed TLS](/docs/development/reference/tls.html).
 
-The sections cover working with these modules in the context of Mbed OS. For generic documentation for both modules, see:
+It covers working with Mbed TLS in the context of Mbed OS. 
 
-- [Mbed TLS full documentation](https://tls.mbed.org/).
-- [Mbed uVisor full documentation](https://docs.mbed.com/docs/uvisor-and-uvisor-lib-documentation/en/latest/).
+For generic documentation, see:
+[Mbed TLS full documentation](https://tls.mbed.org/).
+

--- a/docs/reference/configuration/uVisor.md
+++ b/docs/reference/configuration/uVisor.md
@@ -1,7 +1,0 @@
-<h2 id="configuration-uvisor">uVisor</h2>
-
-```
-Configuration parameters
-------------------------
-
-```

--- a/docs/reference/contributing/target/rtos.md
+++ b/docs/reference/contributing/target/rtos.md
@@ -20,7 +20,6 @@ Option | Value | Description |
 `OS_DYNAMIC_MEM_SIZE` | 0 | RTX dynamic memory is disabled. |
 `OS_TICK_FREQ` | 1000 | Mbed OS Tickrate requires 1ms system tick. |
 `OS_STACK_WATERMARK` | 0 or 1 | Watermarking is enabled if `MBED_STACK_STATS_ENABLED` or `MBED_STACK_STATS_ENABLED` are set. |
-`OS_PRIVILEGE_MODE` | 0 or 1 | We set it for 0 if uVisor is enabled, 1 otherwise. |
 
 #### Code structure
 

--- a/docs/tools/debug/local_debugging_toolchain.md
+++ b/docs/tools/debug/local_debugging_toolchain.md
@@ -106,13 +106,3 @@ You now have set up a debug connection. From here, you can flash debug builds, s
 1. Debugging with [Eclipse](/docs/development/tutorials/eclipse.html).
 1. Debugging with [Keil uVision](/docs/development/tutorials/keil-uvision.html).
 1. Debugging with [Visual Studio Code](/docs/development/tutorials/visual-studio-code.html).
-
-### Semihosting messages
-
-It's possible to send messages from the development board to your computer over the debug port using [semihosting](http://www.keil.com/support/man/docs/armcc/armcc_pge1358787046598.htm). Some parts of Mbed OS 5 also use this, such as uVisor. To see semihosting messages:
-
-1. Install [Netcat](https://en.wikipedia.org/wiki/Netcat).
-2. Connect pyOCD or OpenOCD to your board.
-3. Run `nc localhost 4444`.
-
-<span class="notes">**Note:** uVisor sends most of its messages during startup, so attach Netcat before starting your program.</span>

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -126,7 +126,6 @@ When you use target inheritance, you may alter the values of `extra_labels` usin
 #### `features`, `features_add` and `features_remove`
 
 The list of _features_ enables software features on a platform. Like `extra_labels`, `features` makes the build system aware of additional directories it must scan for resources. Unlike `extra_labels`, the build system recognizes a fixed set of values in the `features` list. The build system recognizes the following features:
- - `UVISOR`.
  - `BLE`.
  - `CLIENT`.
  - `IPV4`.


### PR DESCRIPTION
Remove UVISOR references from Handbook since it is being deprecated from Mbed OS

* Note: An entire paragraph of semihosting was removed, since AFAIK, the UVISOR was the only module which implemented it.
