### PR TITLE
Aligned to other API docs

### DIFF
--- a/docs/reference/api/platform/Rtc.md
+++ b/docs/reference/api/platform/Rtc.md
@@ -1,6 +1,6 @@
 ## RTC
 
-The RTC (Real-Time Clock) class provides mechanisms to set the current time of the hardware RTC with `set_time` API. The time is set as an offset measured in seconds from the time epoch (Unix Epoch - January 1, 1970).
+The RTC (Real-Time Clock) provides mechanisms to set the current time of the hardware RTC with `set_time` API. The time is set as an offset measured in seconds from the time epoch (Unix Epoch - January 1, 1970).
 
 You can use the `attach_rtc` API to hook external RTC for using C time functions. It provides you with `init()`, `read()`, `write()` and `isenabled()` functions to be attached. [Time](/docs/development/reference/time.html) provides more information about C `date` and `time` standard library functions.
 
@@ -8,7 +8,7 @@ RTC class APIs are thread safe.
 
 RTC can keep track of time even in a powered down state if the secondary source of power (battery) is connected.
 
-### RTC Time class reference
+### RTC function reference
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/mbed__rtc__time_8h_source.html)
 

--- a/docs/reference/api/platform/Time.md
+++ b/docs/reference/api/platform/Time.md
@@ -6,7 +6,7 @@ You can convert time to a human-readable format using `ctime`, `localtime`, `str
 
 You cannot use `time`, `mktime` and `localtime` C standard library functions in an interrupt handler with the GCC toolchain. We have added dedicated routines `_rtc_mktime` and `_rtc_localtime`, which are optimized and faster then C standard library functions, to overcome this issue.
 
-### Time class reference
+### Time function reference
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/mbed__mktime_8h_source.html)
 

--- a/docs/reference/api/platform/Wait.md
+++ b/docs/reference/api/platform/Wait.md
@@ -6,7 +6,7 @@ Wait functions provide simple wait capabilities. The OS scheduler puts the curre
 
 When you call wait, your board's CPU will sleep in the RTOS for the whole number of milliseconds and then spin as necessary to make up the remaining fraction of a millisecond. However, it blocks the platform deep sleep for the entire duration.
 
-### Wait functions reference
+### Wait function reference
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/mbed__wait__api_8h_source.html)
 

--- a/docs/reference/api/platform/Wait.md
+++ b/docs/reference/api/platform/Wait.md
@@ -8,7 +8,7 @@ When you call wait, your board's CPU will sleep in the RTOS for the whole number
 
 ### Wait functions reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/mbed__wait__api_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/mbed__wait__api_8h_source.html)
 
 ### Example
 

--- a/docs/reference/api/platform/Wait.md
+++ b/docs/reference/api/platform/Wait.md
@@ -2,30 +2,13 @@
 
 Wait functions provide simple wait capabilities. The OS scheduler puts the current thread in `waiting state`, allowing another thread to execute. Even better: If there are no other threads in `ready state`, it can put the whole microcontroller to `sleep`, saving energy.
 
-```
-/** Waits for a number of seconds, with microsecond resolution (within
- *  the accuracy of single precision floating point).
- *
- *  @param s number of seconds to wait
- */
-void wait(float s);
-
-/** Waits a number of milliseconds.
- *
- *  @param ms the whole number of milliseconds to wait
- */
-void wait_ms(int ms);
-
-/** Waits a number of microseconds.
- *
- *  @param us the whole number of microseconds to wait
- */
-void wait_us(int us);
-```
-
 ### Avoiding OS delay
 
 When you call wait, your board's CPU will sleep in the RTOS for the whole number of milliseconds and then spin as necessary to make up the remaining fraction of a millisecond. However, it blocks the platform deep sleep for the entire duration.
+
+### Wait functions reference
+
+[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/mbed__wait__api_8h_source.html)
 
 ### Example
 


### PR DESCRIPTION
Aligned to other API docs, API's were listed as static code, instead of linking to doxy.