### PR TITLE
Sleep, tickers, RTC APIs are now on master

### DIFF
--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -48,7 +48,7 @@ Hardware low power ticker capabilities.
 
 You can find the API and specification for the low power ticker API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html)
 
 To enable low power ticker support in Mbed OS, add the `LPTICKER` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -62,8 +62,8 @@ mbed test -t <toolchain> -m <target> -n tests-mbed_hal-common_ticker*,tests-mbed
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__ticker__tests.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker__tests.html)

--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -2,8 +2,6 @@
 
 Implementing the low power ticker enables Mbed OS to perform power efficient timing operations that only request millisecond accuracy. You can use this API to schedule events, record elapsed time and drive the tickless OS scheduler.
 
-<span class="warnings">**Warning:** We are changing the low power ticker HAL API in an upcoming release of Mbed OS. This page documents code that exists on a feature branch of Mbed OS. You can find details on how it may affect you in the [implementing the low power ticker API](#implementing-the-low-power-ticker-api) section.
-
 ### Assumptions
 
 #### Defined behavior
@@ -48,11 +46,7 @@ Hardware low power ticker capabilities.
 
 ### Implementing the low power ticker API
 
-We are working on the new HAL low power ticker API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the low power ticker API in both variants. First, you need to implement the current API. You can find it on master branch:
-
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/lp__ticker__api_8h_source.html)
-
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-ticker` branch. You can find the API and specification for the new low power ticker API in the following header file:
+You can find the API and specification for the low power ticker API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__lp__ticker.html)
 

--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -48,7 +48,7 @@ Hardware low power ticker capabilities.
 
 You can find the API and specification for the low power ticker API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html)
 
 To enable low power ticker support in Mbed OS, add the `LPTICKER` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -62,8 +62,8 @@ mbed test -t <toolchain> -m <target> -n tests-mbed_hal-common_ticker*,tests-mbed
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__ticker__tests.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker__tests.html)

--- a/docs/reference/contributing/target/rtc.md
+++ b/docs/reference/contributing/target/rtc.md
@@ -2,8 +2,6 @@
 
 Implementing RTC enables Mbed OS to keep track of the current time. The standard library time keeping functions, such as `time`, use it.
 
-<span class="warnings">**Warning:** We are changing the RTC HAL API in an upcoming release of Mbed OS. This page documents code that exists on a feature branch of Mbed OS. You can find details on how it may affect you in the [Implementing the RTC API](#implementing-the-rtc-api) section.
-
 ### Assumptions
 
 #### Defined behavior
@@ -32,11 +30,7 @@ Hardware RTC capabilities.
 
 ### Implementing the RTC API
 
-We are working on the new HAL RTC API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the RTC API in both variants. First, you need to implement the current API. You can find it on the master branch:
-
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/rtc__api_8h_source.html)
-
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-rtc` branch. You can find the API and specification for the new RTC API in the following header file:
+You can find the API and specification for the RTC API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-rtc-doxy/group__hal__rtc.html)
 

--- a/docs/reference/contributing/target/sleep.md
+++ b/docs/reference/contributing/target/sleep.md
@@ -1,7 +1,5 @@
 ## Sleep
 
-<span class="warnings">**Warning:** We are changing the Sleep HAL API in an upcoming release of Mbed OS. This page documents code that exists on a feature branch of Mbed OS. You can find details on how it may affect you in the [Implementing the Sleep API](#implementing-the-sleep-api) section.
-
 Implement the Sleep HAL API to enable your device to go into a low power state when you are not actively using it.
 
 ### Assumptions
@@ -26,11 +24,7 @@ The core system clock is disabled. You can only enable the low-frequency clocks 
 
 ### Implementing the Sleep API
 
-We are working on the new HAL Sleep API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the Sleep API in both variants. First, you need to implement the current API. You can find it on the master branch:
-
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/sleep__api_8h_source.html)
-
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-sleep` branch. You can find the API and specification for the new Sleep API in the following header file:
+You can find the API and specification for the sleep API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep.html)
 

--- a/docs/reference/contributing/target/sleep.md
+++ b/docs/reference/contributing/target/sleep.md
@@ -26,7 +26,7 @@ The core system clock is disabled. You can only enable the low-frequency clocks 
 
 You can find the API and specification for the sleep API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__sleep.html)
 
 To enable sleep support in Mbed OS, you need to add the `SLEEP` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -40,4 +40,4 @@ mbed test -t <toolchain> -m <target> -n "tests-mbed_hal-sleep*"
 
 You can read more about the test cases:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-sleep-doxy/group__hal__sleep__tests.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__sleep__tests.html)

--- a/docs/reference/contributing/target/sleep.md
+++ b/docs/reference/contributing/target/sleep.md
@@ -26,7 +26,7 @@ The core system clock is disabled. You can only enable the low-frequency clocks 
 
 You can find the API and specification for the sleep API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__sleep.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__sleep.html)
 
 To enable sleep support in Mbed OS, you need to add the `SLEEP` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -40,4 +40,4 @@ mbed test -t <toolchain> -m <target> -n "tests-mbed_hal-sleep*"
 
 You can read more about the test cases:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__sleep__tests.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__sleep__tests.html)

--- a/docs/reference/contributing/target/us_ticker.md
+++ b/docs/reference/contributing/target/us_ticker.md
@@ -2,8 +2,6 @@
 
 Implementing the microsecond ticker enables Mbed OS to perform operations that require precise timing. You can use this API to schedule events, record elapsed time and perform submillisecond delays.
 
-<span class="warnings">**Warning:** We are changing the microsecond ticker HAL API in an upcoming release of Mbed OS. This page documents code that exists on a feature branch of Mbed OS. You can find details on how it may affect you in the [implementing the microsecond ticker API](#implementing-the-microsecond-ticker-api) section.
-
 ### Assumptions
 
 #### Defined behavior
@@ -42,11 +40,7 @@ To implement this API, the device must have a hardware counter that has a count 
 
 ### Implementing the microsecond ticker API
 
-We are working on the new HAL microsecond ticker API, which will replace the current version in an upcoming release of Mbed OS. You need to implement the microsecond ticker API in both variants. First, you need to implement the current API. You can find it on the master branch:
-
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/us__ticker__api_8h_source.html)
-
-To make sure your platform is ready for the upcoming changes, you need to implement the future API and submit it in a separate pull request against the `feature-hal-spec-ticker` branch. You can find the API and specification for the new microsecond ticker API in the following header file:
+You can find the API and specification for the microsecond ticker API in the following header file:
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
 

--- a/docs/reference/contributing/target/us_ticker.md
+++ b/docs/reference/contributing/target/us_ticker.md
@@ -42,7 +42,7 @@ To implement this API, the device must have a hardware counter that has a count 
 
 You can find the API and specification for the microsecond ticker API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker.html)
 
 To enable microsecond ticker support in Mbed OS, add the `USTICKER` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -56,8 +56,8 @@ mbed test -t <toolchain> -m <target> -n tests-mbed_hal-common_ticker*,tests-mbed
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__ticker__tests.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker__tests.html)

--- a/docs/reference/contributing/target/us_ticker.md
+++ b/docs/reference/contributing/target/us_ticker.md
@@ -42,7 +42,7 @@ To implement this API, the device must have a hardware counter that has a count 
 
 You can find the API and specification for the microsecond ticker API in the following header file:
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker.html)
 
 To enable microsecond ticker support in Mbed OS, add the `USTICKER` label in the `device_has` option of the target's section in the `targets.json` file.
 
@@ -56,8 +56,8 @@ mbed test -t <toolchain> -m <target> -n tests-mbed_hal-common_ticker*,tests-mbed
 
 You can read more about the test cases:
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__ticker__tests.html)
 
- [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/development/feature-hal-spec-ticker-doxy/group__hal__us__ticker__tests.html)
+ [![View code](https://www.mbed.com/embed/?type=library)](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__us__ticker__tests.html)


### PR DESCRIPTION
Sleep, tickers (lp and us), RTC APIs are merged to master. This PR removes feature branch vs master distinction.

# TODO
- [ ] update api links when doxy for the new release (or new master) is available