### PR TITLE
workflow: add triage comment

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -40,7 +40,7 @@ Please submit all Mbed OS bugs [on the forums](https://os.mbed.com/forum/bugs-su
 
 The bug report should be reproducible (fails for others) and specific (where and how it fails). We will close insufficient bug reports. 
 
-Issues reported on Github are internally copied to our internal tracker (`ARM Internal Ref: MBOTRIAGE-XXX` comment in the issues and label mirrored set once copied) and regularly triaged.
+We copy issues reported on GitHub to our internal tracker (`ARM Internal Ref: MBOTRIAGE-XXX` comment in the issues and label mirrored set once copied) and regularly triage them.
 
 ### Guidelines for GitHub pull requests
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -38,7 +38,9 @@ Please create separate pull requests for each concern; each pull request needs a
 
 Please submit all Mbed OS bugs [on the forums](https://os.mbed.com/forum/bugs-suggestions/).
 
-The bug report should be reproducible (fails for others) and specific (where and how it fails). We will close insufficient bug reports.
+The bug report should be reproducible (fails for others) and specific (where and how it fails). We will close insufficient bug reports. 
+
+Issues reported on Github are internally copied to our internal tracker (`ARM Internal Ref: MBOTRIAGE-XXX` comment in the issues and label mirrored set once copied) and regularly triaged.
 
 ### Guidelines for GitHub pull requests
 


### PR DESCRIPTION
I would like to address new triage comments in Github issues. To inform users we triage, and leave some comments in the issues + label. Please review

This is addressing questions like this one https://github.com/ARMmbed/mbed-os/issues/7190#issuecomment-396563501