### PR TITLE
Clarification of CRC API

### DIFF
--- a/docs/reference/api/drivers/MbedCRC.md
+++ b/docs/reference/api/drivers/MbedCRC.md
@@ -1,10 +1,12 @@
-## MbedCRC
+## CRC
 
-The MbedCRC Class provides software CRC generation algorithms. MbedCRC is a template class with polynomial value and polynomial width as arguments.
+The MbedCRC Class provides support for CRC (Cyclic Redundancy Check) algorithms. MbedCRC is a template class with polynomial value and polynomial width as arguments.
 
 You can use the `compute` API to calculate CRC for the selected polynomial. If data is available in parts, you must call the `compute_partial_start`, `compute_partial` and `compute_partial_stop` APIs in the proper order to get the correct CRC value. You can use the `get_polynomial` and `get_width` APIs to learn the current object's polynomial and width values.
 
 ROM polynomial tables are for supported 8/16-bit CCITT, 16-bit IBM and 32-bit ANSI polynomials. By default, ROM tables are used for CRC computation. If ROM tables are not available, then CRC is computed at runtime bit by bit for all data input.
+
+For platforms that support [Hardware CRC](https://os.mbed.com/docs/v5.9/reference/hardware-crc.html), the MbedCRC API replaces the software implementation of CRC to take advantage of the hardware acceleration provided by the platform.
 
 ### MbedCRC class reference
 


### PR DESCRIPTION
- Propose to remove 'Mbed' from the side panel, as it seems redundant.
https://os.mbed.com/docs/v5.9/reference/mbedcrc.html

- Clarified that the CRC API can take advantage of the HW CRC feature provided by the platform.

@AnotherButler @bulislaw 