### PR TITLE
Design: remove diagram

### DIFF
--- a/docs/reference/contributing/guidelines/design_guidelines.md
+++ b/docs/reference/contributing/guidelines/design_guidelines.md
@@ -17,27 +17,6 @@ The Arm Mbed OS codebase is organized into conceptual submodules to limit the sc
 
 - Modules should be logically grouped in the OS tree. Avoid generic words; be intentional with naming.
 
-    ```
-    - mbed-os
-        |- rtos - user API + any layer required to fit into mbed OS
-        |   |- rtx - third party implementation
-        |   |- windows - third party implementation
-        |   `- tests
-        |       |- unit - rtos related unit tests
-        |       `- functional - rtos related functional tests
-        |- drivers - user API on-chip hardware interfaces (Ticker, DigitalOut, etc)
-        |- util - chip-independent layer (retarget, toolchain, etc)
-        |   `- bootloader - chip-independent bootloader
-        |- net - networking API
-        |   |- stack - network implementations  
-        |   |   |-lwip
-        |   |   `- nanostack
-        |   `- tests - network tests
-        `- tests
-        |- integration - mbed OS integration tests
-        `- smoke - mbed OS smoke tests (blinky, etc)
-    ```
-
 - Prefix each source file with the module name followed by an underscore. This prevents conflicts with other similarly named files in different modules such as `nanostack/thread.c` and `drivers/Thread.cpp`; not all toolchains are able to support object files with the same name.
 
     ```


### PR DESCRIPTION
Fixes #623 by removing the confusing diagram. It shall be obvious from
Mbed OS structure - what modules we have and how we organize it.

We can add the link to the actual Mbed OS module description (the tree overview), we should have it somewhere.