### PR TITLE
Changed NV to volatile in HeapBlockDevice

### DIFF
--- a/docs/api/storage/HeapBlockDevice.md
+++ b/docs/api/storage/HeapBlockDevice.md
@@ -2,7 +2,7 @@
 
 <span class="images">![](https://os.mbed.com/docs/development/mbed-os-api-doxy/class_heap_block_device.png)<span>BlockDevice class hierarchy</span></span>
 
-The HeapBlockDevice class provides a way to simulate block devices for software development or testing. The created blocks are nonvolatile; they do not persist across power cycles.
+The HeapBlockDevice class provides a way to simulate block devices for software development or testing. The created blocks are volatile; they do not persist across power cycles.
 
 HeapBlockDevices have the following configurable parameters in either one of two constructors:
 


### PR DESCRIPTION
Media that does not persist across power cycles is volatile. It's not nonvolatile.