### PR TITLE
Change 115200 baudrate notes for quickstart to 9600

### DIFF
--- a/docs/tutorials/quickstart/example_walkthrough.md
+++ b/docs/tutorials/quickstart/example_walkthrough.md
@@ -6,7 +6,7 @@ The quick start example blinks the LED on your board on and off. The main thread
 
 To view the serial output use any terminal client, such as [PuTTY](http://www.putty.org/) or [CoolTerm](http://freeware.the-meiers.org/).
 
-The default baud rate, or speed, for this application is set to `115200`. You can modify it in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port.
+The default baud rate, or speed, for this application is set to `9600`. You can modify it in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port.
 
 <span class="tips">**Tip:** You can find more information on the Mbed OS configuration tools and serial communication in Mbed OS in the [related links section](#related-links).</span>
 

--- a/docs/tutorials/quickstart/quick-start-cli-debug.md
+++ b/docs/tutorials/quickstart/quick-start-cli-debug.md
@@ -7,7 +7,7 @@ The easiest way to do basic debugging is to use the `printf` command in your cod
 
 For example, add `printf("Hello World!\n\r");` to the top of your main function, and then recompile the program and flash it to your device.
 
-<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. This value can be modified in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
+<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. You can modify this value in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
 
 ### Exporting to a desktop IDE
 

--- a/docs/tutorials/quickstart/quick-start-cli-debug.md
+++ b/docs/tutorials/quickstart/quick-start-cli-debug.md
@@ -7,7 +7,7 @@ The easiest way to do basic debugging is to use the `printf` command in your cod
 
 For example, add `printf("Hello World!\n\r");` to the top of your main function, and then recompile the program and flash it to your device.
 
-<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. The `mbed-os-example-blinky` example runs at a baud rate of `115200` and can be modified in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
+<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. This value can be modified in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
 
 ### Exporting to a desktop IDE
 

--- a/docs/tutorials/quickstart/quick-start-online-debug.md
+++ b/docs/tutorials/quickstart/quick-start-online-debug.md
@@ -6,7 +6,7 @@ The easiest way to do basic debugging is to use the `printf` command in your cod
 
 For example, add `printf("Hello World!\n\r");` to the top of your main function, and then recompile the program and flash it to your device.
 
-<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. The `mbed-os-example-blinky` example runs at a baud rate of `115200` and can be modified in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
+<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. This value can be modified in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
 
 To determine which communication port your board connects to:
 

--- a/docs/tutorials/quickstart/quick-start-online-debug.md
+++ b/docs/tutorials/quickstart/quick-start-online-debug.md
@@ -6,7 +6,7 @@ The easiest way to do basic debugging is to use the `printf` command in your cod
 
 For example, add `printf("Hello World!\n\r");` to the top of your main function, and then recompile the program and flash it to your device.
 
-<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. This value can be modified in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
+<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. You can modify this value in the `mbed_app.json` file. To configure your terminal client to this baud rate, change the speed option when selecting the port. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span>
 
 To determine which communication port your board connects to:
 


### PR DESCRIPTION
https://github.com/ARMmbed/mbed-os-example-blinky/pull/155 changes the quick start application to run at the serial line at 9600. Updates the docs to reflect this.