### PR TITLE
Move the SPIFBlockDevice example to an external repo

### DIFF
--- a/docs/api/storage/SPIFBlockDevice.md
+++ b/docs/api/storage/SPIFBlockDevice.md
@@ -14,38 +14,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 ### SPIFBlockDevice example
 
-``` cpp TODO
-// Here's an example using the MX25R SPI flash device on the K82F
-#include "mbed.h"
-#include "SPIFBlockDevice.h"
-
-// Create flash device on SPI bus with PTE5 as chip select
-SPIFBlockDevice spif(PTE2, PTE4, PTE1, PTE5);
-
-int main() {
-    printf("spif test\n");
-
-    // Initialize the SPI flash device and print the memory layout
-    spif.init();
-    printf("spif size: %llu\n",         spif.size());
-    printf("spif read size: %llu\n",    spif.get_read_size());
-    printf("spif program size: %llu\n", spif.get_program_size());
-    printf("spif erase size: %llu\n",   spif.get_erase_size());
-
-    // Write "Hello World!" to the first block
-    char *buffer = (char*)malloc(spif.get_erase_size());
-    sprintf(buffer, "Hello World!\n");
-    spif.erase(0, spif.get_erase_size());
-    spif.program(buffer, 0, spif.get_erase_size());
-
-    // Read back what was stored
-    spif.read(buffer, 0, spif.get_erase_size());
-    printf("%s", buffer);
-
-    // Deinitialize the device
-    spif.deinit();
-}
-```
+[![View Example]https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/SPIFBlockDevice)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/SPIFBlockDevice/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/SPIFBlockDevice.md
+++ b/docs/api/storage/SPIFBlockDevice.md
@@ -14,7 +14,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 ### SPIFBlockDevice example
 
-[![View Example]https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/SPIFBlockDevice)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/SPIFBlockDevice/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/SPIFBlockDevice)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/SPIFBlockDevice/main.cpp)
 
 ### Related content
 


### PR DESCRIPTION
This is related to https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/18 and should wait for it