### PR TITLE
DTLSSocket example paragraph added

### DIFF
--- a/docs/api/networksocket/DTLSSocket.md
+++ b/docs/api/networksocket/DTLSSocket.md
@@ -14,7 +14,7 @@ To use secure DTLS connections, application use the `DTLSSocketWrapper` through 
 
 Please see the TLSSocket example:
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/development/mbed-os-api-doxy/class_t_l_s_socket.html)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-tls-socket/blob/master/)](https://github.com/ARMmbed/mbed-os-example-tls-socket/blob/master/main.cpp)
 
 ### Related content
 

--- a/docs/api/networksocket/DTLSSocket.md
+++ b/docs/api/networksocket/DTLSSocket.md
@@ -10,6 +10,10 @@ To use secure DTLS connections, application use the `DTLSSocketWrapper` through 
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/development/mbed-os-api-doxy/class_d_t_l_s_socket.html)
 
+### DTLSSocket example
+
+Please see the [TLSSocket](tlssocket.html) example.
+
 ### Related content
 
 - [Secure Socket](../reference/secure-socket.html)

--- a/docs/api/networksocket/DTLSSocket.md
+++ b/docs/api/networksocket/DTLSSocket.md
@@ -12,9 +12,11 @@ To use secure DTLS connections, application use the `DTLSSocketWrapper` through 
 
 ### DTLSSocket example
 
-Please see the [TLSSocket](tlssocket.html) example.
+Please see the TLSSocket example:
+
+[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/development/mbed-os-api-doxy/class_t_l_s_socket.html)
 
 ### Related content
 
-- [Secure Socket](../reference/secure-socket.html)
-- [TLSSocket](tlssocket.html)
+- [Secure Socket](../reference/secure-socket.html).
+- [TLSSocket](tlssocket.html).


### PR DESCRIPTION
DTLSSocket don't need own example, because it would be so close to TLSSocket example. 