### PR TITLE
Move the SDBlockDevice example to an external repo

### DIFF
--- a/docs/api/storage/SDBlockDevice.md
+++ b/docs/api/storage/SDBlockDevice.md
@@ -72,55 +72,7 @@ The figure above shows the Mbed OS software component stack used for data storag
 
 ### SDBlockDevice example application
 
-The following sample code illustrates how to use the SD block device API:
-
-``` cpp TODO
-#include "mbed.h"
-#include "SDBlockDevice.h"
-
-// Instantiate the SDBlockDevice by specifying the SPI pins connected to the SDCard
-// socket. The PINS are:
-//     MOSI (Master Out Slave In)
-//     MISO (Master In Slave Out)
-//     SCLK (Serial Clock)
-//     CS (Chip Select)
-SDBlockDevice sd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, MBED_CONF_SD_SPI_CS);
-uint8_t block[512] = "Hello World!\n";
-
-int main()
-{
-    // call the SDBlockDevice instance initialisation method.
-    if ( 0 != sd.init()) {
-        printf("Init failed \n");
-        return -1;
-    }
-    printf("sd size: %llu\n",         sd.size());
-    printf("sd read size: %llu\n",    sd.get_read_size());
-    printf("sd program size: %llu\n", sd.get_program_size());
-    printf("sd erase size: %llu\n",   sd.get_erase_size());
-
-    // set the frequency
-    if ( 0 != sd.frequency(5000000)) {
-        printf("Error setting frequency \n");
-    }
-
-    if ( 0 != sd.erase(0, sd.get_erase_size())) {
-        printf("Error Erasing block \n");
-    }
-
-    // Write some the data block to the device
-    if ( 0 == sd.program(block, 0, 512)) {
-        // read the data block from the device
-        if ( 0 == sd.read(block, 0, 512)) {
-            // print the contents of the block
-            printf("%s", block);
-        }
-    }
-
-    // call the SDBlockDevice instance de-initialisation method.
-    sd.deinit();
-}
-```
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/SDBlockDevice)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/SDBlockDevice/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/SDBlockDevice.md
+++ b/docs/api/storage/SDBlockDevice.md
@@ -72,7 +72,7 @@ The figure above shows the Mbed OS software component stack used for data storag
 
 ### SDBlockDevice example application
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/SDBlockDevice)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/SDBlockDevice/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/SDBlockDevice)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/SDBlockDevice/main.cpp)
 
 ### Related content
 


### PR DESCRIPTION
This is related to https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/21 and should wait for it