### PR TITLE
Updating examples link in MBRBlockDevice.md, ProfilingBlockDevice.md and SlicingBlockDevice.md

### DIFF
--- a/docs/api/storage/MBRBlockDevice.md
+++ b/docs/api/storage/MBRBlockDevice.md
@@ -23,7 +23,7 @@ Partition a heap backed block device into two partitions. This example also uses
 
 Partition an SD card, and format the new partition with a FAT filesystem. A PC will now be able to recognize the SD card.
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_1/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_2/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/MBRBlockDevice.md
+++ b/docs/api/storage/MBRBlockDevice.md
@@ -19,11 +19,11 @@ You can view more information about the configurable settings and functions in t
 
 Partition a heap backed block device into two partitions. This example also uses the [HeapBlockDevice](heapblockdevice.html).
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/MBRBlockDevice_ex_1/)](https://os.mbed.com/teams/mbed_example/code/MBRBlockDevice_ex_1/file/daa62d7aa9f9/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_1/main.cpp)
 
 Partition an SD card, and format the new partition with a FAT filesystem. A PC will now be able to recognize the SD card.
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/MBRBlockDevice_ex_2/)](https://os.mbed.com/teams/mbed_example/code/MBRBlockDevice_ex_2/file/a48b7099a59c/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_1/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/MBRBlockDevice.md
+++ b/docs/api/storage/MBRBlockDevice.md
@@ -19,11 +19,11 @@ You can view more information about the configurable settings and functions in t
 
 Partition a heap backed block device into two partitions. This example also uses the [HeapBlockDevice](heapblockdevice.html).
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_1/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/MBRBlockDevice/MBRBlockDevice_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/MBRBlockDevice/MBRBlockDevice_ex_1/main.cpp)
 
 Partition an SD card, and format the new partition with a FAT filesystem. A PC will now be able to recognize the SD card.
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/MBRBlockDevice_ex_2/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/MBRBlockDevice/MBRBlockDevice_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/MBRBlockDevice/MBRBlockDevice_ex_2/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/ProfilingBlockDevice.md
+++ b/docs/api/storage/ProfilingBlockDevice.md
@@ -16,7 +16,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 Create a ProfilingBlockDevice, perform storage operations and report back the read, write and erase counts.
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/ProfilingBlockDevice/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/ProfilingBlockDevice/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/ProfilingBlockDevice/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/ProfilingBlockDevice/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/ProfilingBlockDevice.md
+++ b/docs/api/storage/ProfilingBlockDevice.md
@@ -16,7 +16,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 Create a ProfilingBlockDevice, perform storage operations and report back the read, write and erase counts.
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/ProfilingBlockDevice_ex_1/)](https://os.mbed.com/teams/mbed_example/code/ProfilingBlockDevice_ex_1/file/20bf5212cdd6/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/ProfilingBlockDevice/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/ProfilingBlockDevice/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/SlicingBlockDevice.md
+++ b/docs/api/storage/SlicingBlockDevice.md
@@ -20,7 +20,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 This SlicingBlockDevice example partitions a [HeapBlockDevice](heapblockdevice.html) into three subunits and showcases programming and reading back data segments through both the underlying master block device and the sliced subunits.
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/SlicingBlockDevice/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/SlicingBlockDevice/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/SlicingBlockDevice/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/blockdevices/SlicingBlockDevice/main.cpp)
 
 ### Related content
 

--- a/docs/api/storage/SlicingBlockDevice.md
+++ b/docs/api/storage/SlicingBlockDevice.md
@@ -20,7 +20,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 This SlicingBlockDevice example partitions a [HeapBlockDevice](heapblockdevice.html) into three subunits and showcases programming and reading back data segments through both the underlying master block device and the sliced subunits.
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/SlicingBlockDevice_ex_1/)](https://os.mbed.com/teams/mbed_example/code/SlicingBlockDevice_ex_1/file/62c01cd06ff7/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/SlicingBlockDevice/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/tree/master/SlicingBlockDevice/main.cpp)
 
 ### Related content
 


### PR DESCRIPTION
Examples of MBRBlockDevice, ProfilingBlockDevice and SlicingBlockDevice are moving into mbed-os-examples-docs_only and this PR intends to update the links in the related documents