### PR TITLE
Update tools docs to point to mbed-os-tools.

### DIFF
--- a/docs/porting/porting_full_process/built_in_tests.md
+++ b/docs/porting/porting_full_process/built_in_tests.md
@@ -29,9 +29,10 @@ The platform under test needs to be supported in mbedls for automated tests to w
 
 If an updated mbedls pip package including support for your platform hasn't been released yet, you need to direct pip to use your local directory (which includes the code changes to support the new platform):
 
-1. Clone [https://github.com/ARMmbed/mbed-ls](https://github.com/ARMmbed/mbed-ls).
-1. [Add your target to the platform database](https://github.com/ARMmbed/mbed-ls#adding-platform-support)
-1. Run `pip install --editable <your_local_root_to_mbed-ls>`.
+1. Clone [https://github.com/ARMmbed/mbed-os-tools](https://github.com/ARMmbed/mbed-os-tools).
+1. [Add your target to the platform database](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-ls#adding-platform-support)
+1. Run `pip install --editable <your_local_root_to_mbed-os-tools>`.
+1. Run `pip install --editable <your_local_root_to_mbed-os-tools>/packages/mbed-ls`.
 1. If you're using an external serial probe (like an FTDI USB cable), create an `mbedls.json` file and specify the serial port.
 
     The serial port path varies in different operation systems. On **Windows**, you can find it through Device Manager; it will usually be something like `COM#`. On **Mac OS** you can use `ls /dev/tty.usb*`. On Linux you can use `ls /dev/ttyACM*`. The format of `mbedls.json` is as follows:
@@ -210,4 +211,4 @@ To build and run the Mbed OS tests:
 
 1. Before you begin the test run, please make sure the serial port is not already opened by programs like Screen or Teraterm (close them if they're open). In addition, verify `mbedls` lists the new target device.
 
-    If your test run doesn't start, please read about [troubleshooting Greentea](https://github.com/armmbed/greentea#common-issues).
+    If your test run doesn't start, please read about [troubleshooting Greentea](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-greentea#common-issues).

--- a/docs/porting/tools/mbedls.md
+++ b/docs/porting/tools/mbedls.md
@@ -16,6 +16,4 @@ Further, Mbed-ls only detects devices that meet the following criteria:
 
 ### Implementation
 
-When adding a board to Mbed-ls, you typically need to add a new definition to the platform database. Before you add your board to the Mbed-ls platform database, you need the Unique product code, a four-digit hexadecimal identifier, you obtained through the mbed enabled program. You can add a new board to the platform database by adding an entry mapping from your board's unique product code to the name of the board into the `DEFAULT_PLATFORM_DB` dictionary in [`mbed_lstools/platform_database.py`](https://github.com/ARMmbed/mbed-ls/blob/master/mbed_lstools/platform_database.py).
-
-If your board uses an interface firmware other than J-Link, STLink, DAPLink or OpenSDA, you need to add a new vendor string for detection on windows. If you need to add a new vendor string, add it to the `usb_vendor_list` member of the `MbedLsToolsBase` class in [`mbed_lstools/lstools_base.py`](https://github.com/ARMmbed/mbed-ls/blob/master/mbed_lstools/lstools_base.py).
+Please see the [implementation guide](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-ls#adding-platform-support) in Mbed LS for more details.

--- a/docs/reference/configuration/mbed_targets.md
+++ b/docs/reference/configuration/mbed_targets.md
@@ -259,7 +259,7 @@ The `device_name` key in `targets.json` is `MK20DX256xxx7` for any target that u
 
 #### `detect_code`
 
-The `detect_code` contains four ASCII characters containing only hexadecimal values (A-F and 0-9). This code is the same for all platforms of the same type. `Mbed LS` no longer uses this field to identify the platform. Instead, `Mbed LS` has its [own database](https://github.com/ARMmbed/mbed-ls/blob/master/mbed_lstools/platform_database.py#L45) of detect codes.
+The `detect_code` contains four ASCII characters containing only hexadecimal values (A-F and 0-9). This code is the same for all platforms of the same type. `Mbed LS` no longer uses this field to identify the platform. Instead, `Mbed LS` has its [own database](https://github.com/ARMmbed/mbed-os-tools/blob/master/src/mbed_os_tools/detect/platform_database.py) of detect codes.
 
 #### `OUTPUT_EXT`
 

--- a/docs/tools/testing/greentea.md
+++ b/docs/tools/testing/greentea.md
@@ -6,7 +6,7 @@ _**G**eneric **re**gression **en**vironment for **te**st **a**utomation_
 
 Greentea is the automated testing tool for Arm Mbed OS development. It automates the process of flashing Mbed boards, driving the test and accumulating test results into test reports. Developers use it for local development as well as for automation in a Continuous Integration environment.
 
-This document should help you start using Greentea. Please see the [`htrun` documentation](https://github.com/ARMmbed/htrun), the tool Greentea uses to drive tests, for the technical details of the interactions between the platform and the host machine.
+This document should help you start using Greentea. Please see the [`htrun` documentation](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests), the tool Greentea uses to drive tests, for the technical details of the interactions between the platform and the host machine.
 
 ### Prerequisites
 
@@ -159,7 +159,7 @@ $ mbedgt --use-tids 02400203C3423E603EBEC3D8,024002031E031E6AE3FFE3D2
 
 Where `02400203C3423E603EBEC3D8` and `024002031E031E6AE3FFE3D` are the target IDs of platforms attached to your system.
 
-You can view target IDs using the [`mbed-ls`](https://github.com/ARMmbed/mbed-ls) tool (installed with Greentea).
+You can view target IDs using the [`mbed-ls`](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-ls) tool (installed with Greentea).
 
 ```
 $ mbedls

--- a/docs/tools/testing/testing_greentea.md
+++ b/docs/tools/testing/testing_greentea.md
@@ -46,7 +46,7 @@ A test case is named by its position in your project's file structure. For insta
 
 You can build tests through Arm Mbed CLI. For information on using Mbed CLI, please see the [CLI documentation](../tools/developing-mbed-cli.html).
 
-When you build tests for a target and a toolchain, the script first discovers the available tests and then builds them in parallel. You can also create a **test specification** file, which our testing tools can use to run automated hardware tests. For more information on the test specification file, please see the [Greentea documentation](https://github.com/ARMmbed/greentea#test-specification-json-formatted-input).
+When you build tests for a target and a toolchain, the script first discovers the available tests and then builds them in parallel. You can also create a **test specification** file, which our testing tools can use to run automated hardware tests. For more information on the test specification file, please see the [Greentea documentation](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-greentea#test-specification-json-formatted-input).
 
 ##### Building process
 
@@ -71,9 +71,9 @@ If you need to test with multiple configurations, then you can use the `--app-co
 
 You can run automated tests through Mbed CLI.
 
-The testing process requires that tests be built and that a test specification JSON file that describes these available tests exists. See the [test specification format](https://github.com/ARMmbed/greentea#test-specification-json-formatted-input).
+The testing process requires that tests be built and that a test specification JSON file that describes these available tests exists. See the [test specification format](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-greentea#test-specification-json-formatted-input).
 
-The Greentea tool handles the actual testing process. To read more about this tool, please visit its [GitHub repository](https://github.com/ARMmbed/greentea).
+The Greentea tool handles the actual testing process. To read more about this tool, please visit its [GitHub repository](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-greentea).
 
 #### Writing tests
 
@@ -148,7 +148,7 @@ Assuming your test was exported correctly to your IDE, build the project and loa
 
 Bring the target out of reset and run the program. Your target waits for the test tools to send a synchronizing character string over the serial port. Do not run the `mbed test` commands because that will attempt to flash the device, which you've already done with your IDE.
 
-Instead, you can use the underlying test tools to drive the test. [`htrun`](https://github.com/ARMmbed/htrun) is the tool you need to use in this scenario. Installing the requirements for Mbed OS also installs `htrun`. You can also install `htrun` by running `pip install mbed-host-tests`.
+Instead, you can use the underlying test tools to drive the test. [`htrun`](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) is the tool you need to use in this scenario. Installing the requirements for Mbed OS also installs `htrun`. You can also install `htrun` by running `pip install mbed-host-tests`.
 
 First, find your target's serial port by running the following command:
 

--- a/docs/tools/testing/testing_icetea.md
+++ b/docs/tools/testing/testing_icetea.md
@@ -38,7 +38,7 @@ The full build process is:
 
 You can run automated tests through Mbed CLI with the `--icetea` option. You can find more information about this in the [Mbed CLI test documentation](test-and-debug.html).
 
-The testing process requires that tests be built and that a test specification JSON file that describes these available tests exists. See the [test specification format](https://github.com/ARMmbed/greentea#test-specification-json-formatted-input).
+The testing process requires that tests be built and that a test specification JSON file that describes these available tests exists. See the [test specification format](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-greentea#test-specification-json-format).
 
 The test specification JSON is similar for the Greentea and Icetea tests.
 


### PR DESCRIPTION
This applies for Mbed LS, htrun, and greentea.