### PR TITLE
workflow: functionality changes release notes addition

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -98,7 +98,7 @@ Any change in the functionality, it can be adding a new feature, adding a new me
 
 A feature contribution contains a new API, capability or behavior. It does not break backward compatibility with existing APIs, capabilities or behaviors. New feature contributions are very welcome in Mbed OS. However, because they add capability to the codebase, it's easy for a new feature to introduce bugs and a support burden. The introduction of new features should also come with documentation, majority of targets support and comprehensive test coverage proving the correctness of the feature per the documentation. Feature PRs are treated cautiously, and new features require a new minor version for the codebase. Features are candidates for feature releases. 
 
-Every functionality change pull request must contain a release notes section called "Release notes" to describe the changes to users.
+Every pull request changing or adding functionality must contain a release notes section called "Release notes" to describe the changes to users.
 
 It must contain:
 - brief description of changes introduced

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -106,6 +106,8 @@ It must contain:
 - An analysis of effects: components affected, potential consequences for users and reasons for the addition or change.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 
+<span class="notes">**Note:** We may use this content in our official release notes.</span>
+
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.
 
 Each feature has a tech lead. This person is responsible for:

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -82,7 +82,7 @@ Release: patch
 
 #### Refactor
 
-A refactor is a contribution that modifies the codebase without fixing a bug or changing the existing behavior. Examples of this would be moving functions or variables between translation units, renaming source files or folders, scope modification for nonpublic code, documentation structure changes, and test organization changes. There is always the risk that someone depended on the location or name before a refactor; therefore, these are lower in priority than bug fixes and might require detailed justification for the change. Refactors are candidates for feature releases.
+A refactor is a contribution that modifies the codebase without fixing a bug or changing the existing behavior. Examples of this are moving functions or variables between translation units, renaming source files or folders, scope modification for nonpublic code, documentation structure changes and test organization changes. There is always the risk that someone depended on the location or name before a refactor; therefore, these are lower in priority than bug fixes and might require detailed justification for the change. Refactors are candidates for feature releases.
 
 Release: feature
 
@@ -94,16 +94,17 @@ Release: patch
 
 #### Functionality change
 
-Any change in the functionality, it can be adding a new feature, adding a new method or a function. Software language does not matter.
+A functionality change can be any change in the functionality, including adding a new feature, a new method or a function. Software language does not matter.
 
 A feature contribution contains a new API, capability or behavior. It does not break backward compatibility with existing APIs, capabilities or behaviors. New feature contributions are very welcome in Mbed OS. However, because they add capability to the codebase, it's easy for a new feature to introduce bugs and a support burden. The introduction of new features should also come with documentation, majority of targets support and comprehensive test coverage proving the correctness of the feature per the documentation. Feature PRs are treated cautiously, and new features require a new minor version for the codebase. Features are candidates for feature releases. 
 
 Every pull request changing or adding functionality must contain a release notes section called "Release notes" to describe the changes to users.
 
 It must contain:
-- brief description of changes introduced
-- impact analysis - identify components affected, what are potential consequences for users, why do we need this
-- migration guidance: actions for updating the current code. Good to include code snippets to illustrate, before/after
+
+- A brief description of changes introduced.
+- An impact analysis: components affected, potential consequences for users and reasons for the addition or change.
+- Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.
 
@@ -177,16 +178,16 @@ If a pull request is idle for more than two weeks, it will be closed. The author
 
 #### Reviews
 
-All pull requests must be reviewed. The Arm Mbed CI bot determines the most suitable person to review the pull request (based on the files changed) and tags that person accordingly. Specific, a PR creator can request reviewers by @ tagging people or teams in the *Reviewers* section of the pull request template. For example, @personA @TeamB.
+All pull requests must be reviewed. The Arm Mbed CI bot determines the most suitable person to review the pull request (based on the files changed) and tags that person accordingly. A PR creator can request specific reviewers by @ tagging people or teams in the *Reviewers* section of the pull request template. For example, @personA @TeamB.
 
 GitHub dismisses a reviewer's status after any change to the pull request commit history (such as adding a new commit or rebasing). Smaller changes, such as documentation edits or rebases on top of latest master, only require additional review by maintainers. Their approval is sufficient because a team assigned as a reviewer already approved the pull request.
 
 Label: `needs: review`
 Time: 3 days for reviewers to leave feedback after the maintainers add the "needs: review" label.
 
-#### The CI (Continuous Integration) testing
+#### The Continuous Integration (CI) testing
 
-There are many [CI systems available](../contributing/workflow.html#guidelines-for-github-pull-requests) for testing Mbed OS pull requests and braches. Which CI tests we run against a particular pull request depends on the effect that pull request has on the code base. Irrespective of which CI tests run, Mbed OS has an all green policy, meaning that all the CI jobs that are triggered must pass before we merge the pull request.
+There are many [CI systems available](../contributing/workflow.html#guidelines-for-github-pull-requests) for testing Mbed OS pull requests and braches. Which CI tests we run against a particular pull request depends on the effect that pull request has on the code base. Irrespective of which CI tests run, Mbed OS has an all-green policy, meaning that all the CI jobs that are triggered must pass before we merge the pull request.
 
 Label: `needs: CI`
 Time: 1 day for CI to complete and report back results.

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -103,7 +103,7 @@ Every pull request changing or adding functionality must contain a release notes
 It must contain:
 
 - A brief description of changes introduced.
-- An impact analysis: components affected, potential consequences for users and reasons for the addition or change.
+- An analysis of effects: components affected, potential consequences for users and reasons for the addition or change.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -98,6 +98,12 @@ Any change in the functionality, it can be adding a new feature, adding a new me
 
 A feature contribution contains a new API, capability or behavior. It does not break backward compatibility with existing APIs, capabilities or behaviors. New feature contributions are very welcome in Mbed OS. However, because they add capability to the codebase, it's easy for a new feature to introduce bugs and a support burden. The introduction of new features should also come with documentation, majority of targets support and comprehensive test coverage proving the correctness of the feature per the documentation. Feature PRs are treated cautiously, and new features require a new minor version for the codebase. Features are candidates for feature releases. 
 
+Every functionality change pull request must contain release notes section addition to describe the change to users.
+
+It must contain:
+- description of changes with impact analysis 
+- migration guidance: before and after (good to include code snippets to illustrate)
+
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.
 
 Each feature has a tech lead. This person is responsible for:

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -103,7 +103,7 @@ Every functionality change pull request must contain a release notes section cal
 It must contain:
 - brief description of changes introduced
 - impact analysis - identify components affected, what are potential consequences for users, why do we need this
-- migration guidance: before and after (good to include code snippets to illustrate)
+- migration guidance: actions for updating the current code. Good to include code snippets to illustrate, before/after
 
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -98,10 +98,11 @@ Any change in the functionality, it can be adding a new feature, adding a new me
 
 A feature contribution contains a new API, capability or behavior. It does not break backward compatibility with existing APIs, capabilities or behaviors. New feature contributions are very welcome in Mbed OS. However, because they add capability to the codebase, it's easy for a new feature to introduce bugs and a support burden. The introduction of new features should also come with documentation, majority of targets support and comprehensive test coverage proving the correctness of the feature per the documentation. Feature PRs are treated cautiously, and new features require a new minor version for the codebase. Features are candidates for feature releases. 
 
-Every functionality change pull request must contain release notes section addition to describe the change to users.
+Every functionality change pull request must contain a release notes section called "Release notes" to describe the changes to users.
 
 It must contain:
-- description of changes with impact analysis 
+- brief description of changes introduced
+- impact analysis - identify components affected, what are potential consequences for users, why do we need this
 - migration guidance: before and after (good to include code snippets to illustrate)
 
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.


### PR DESCRIPTION
Every functionality change must contain release notes text addition. This will be
gating functionality change integration.

A user does not need to go through PRs to see what has changed, read the section:
"Functionality changes" in the release notes.

Ready for reviews

cc @ARMmbed/mbed-os-maintainers 

We could get some examples from current funcitonal changes and how release notes should look like. I quickly found one: https://github.com/ARMmbed/mbed-os/pull/9277 

