### PR TITLE
eclipse_pyocd: add link to compatible windows make

### DIFF
--- a/docs/tutorials/debug/eclipse_pyocd.md
+++ b/docs/tutorials/debug/eclipse_pyocd.md
@@ -63,7 +63,10 @@ Once the project builds, you can configure the debugger. The configuration depen
 If the build fails with an error:
 
 1. `make[1]: arm-none-eabi-g++: No such file or directory`, you need to configure Eclipse's PATH (not your OS PATH).
-1. `Program "make" not found in PATH`, install [GNU-Make utility](http://gnuwin32.sourceforge.net/packages/make.htm), and configure Eclipse's PATH.
+1. `Program "make" not found in PATH`, install GNU-Make utility, version at least 4.0:
+    - On Windows, compatible version of make is found in [Cygwin](https://www.cygwin.com/) and [MSYS2](https://www.msys2.org/) distrubitions. Install `make` package and add either `C:/cygwin64/bin` or `C:/msys64/usr/bin` to Eclipse PATH.
+    - On macOS, `make` can be installed as part of [Xcode Command Line Tools](https://developer.apple.com/download/more/).
+    - On Linux, `make` is provided by the distrubition package manager.
 
 Steps to update Eclipse's PATH:
 

--- a/docs/tutorials/debug/eclipse_pyocd.md
+++ b/docs/tutorials/debug/eclipse_pyocd.md
@@ -64,9 +64,9 @@ If the build fails with an error:
 
 1. `make[1]: arm-none-eabi-g++: No such file or directory`, you need to configure Eclipse's PATH (not your OS PATH).
 1. `Program "make" not found in PATH`, install GNU-Make utility, version at least 4.0:
-    - On Windows, compatible version of make is found in [Cygwin](https://www.cygwin.com/) and [MSYS2](https://www.msys2.org/) distrubitions. Install `make` package and add either `C:/cygwin64/bin` or `C:/msys64/usr/bin` to Eclipse PATH.
-    - On macOS, `make` can be installed as part of [Xcode Command Line Tools](https://developer.apple.com/download/more/).
-    - On Linux, `make` is provided by the distrubition package manager.
+    - On Windows, you can find a compatible version of Make in [Cygwin](https://www.cygwin.com/) and [MSYS2](https://www.msys2.org/) distrubitions. Install the `make` package, and add either `C:/cygwin64/bin` or `C:/msys64/usr/bin` to Eclipse's PATH.
+    - On macOS, you can install `make` as part of [Xcode command-line tools](https://developer.apple.com/download/more/).
+    - On Linux, the distrubition package manager provides `make`.
 
 Steps to update Eclipse's PATH:
 


### PR DESCRIPTION
https://github.com/ARMmbed/mbed-os/pull/7583#issuecomment-408130529 mentions it is hard to find make > 3.81 for windows.
Provide links to compatible version of make. Both Cygwin and MSYS2 currently provide 4.2.1:

make --version
GNU Make 4.2.1
Built for x86_64-unknown-cygwin

make --version
GNU Make 4.2.1
Built for x86_64-pc-msys

Make from https://sourceforge.net/projects/gnuwin32/ is NOT compatible with the makefiles exported by mbed-os-5.11, the link is removed.