### PR TITLE
workflow: add new target requirement - tests provided

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -90,9 +90,10 @@ Release: feature
 
 Updating target implementation (adding a new target or updating already supported target) is a change for a patch release.
 
-The test report must be part of the pull request for a new target addition. It must pass all Mbed OS functional and system validation tests for the current Mbed OS major release including all Mbed OS supported toolchains.
+A test report for the new target must be part of the pull request. The new target must pass all Mbed OS functional and system validation tests (using `mbed test` command) for the current Mbed OS major release including all Mbed OS supported toolchains.
 
 Release: patch
+
 
 #### Functionality change
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -90,7 +90,7 @@ Release: feature
 
 Updating target implementation (adding a new target or updating already supported target) is a change for a patch release.
 
-A test report for the new target must be part of the pull request. The new target must pass all Mbed OS functional and system validation tests (using `mbed test` command) for the current Mbed OS major release including all Mbed OS supported toolchains.
+A test report for the new target must be part of the pull request. The new target must pass all Mbed OS functional and system validation tests (using `mbed test` command) for the current Mbed OS major release, including all Mbed OS supported toolchains.
 
 Release: patch
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -90,6 +90,8 @@ Release: feature
 
 Updating target implementation (adding a new target or updating already supported target) is a change for a patch release.
 
+The test report must be part of the pull request for a new target addition. It must pass all Mbed OS functional and system validation tests for the current Mbed OS major release including all Mbed OS supported toolchains.
+
 Release: patch
 
 #### Functionality change


### PR DESCRIPTION
We always require test results as part of new target. We should have this captured in the documentation.

I've added a new paragraph to "PR type: target update". Or shall this be captured somewhere else?

@ARMmbed/mbed-os-maintainers 