### PR TITLE
Quickstart baremetal notes

### DIFF
--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -21,7 +21,7 @@
 
    <span class="tips">**Tip:** You can get the name of the board plugged into your computer by running `mbed detect`, and you can get a full list of supported toolchains and targets by running the `mbed compile --supported` command.</span>
 
-    1. **NOTE** To build with the Mbed OS Bare Metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file as in the following snippet:
+   <span class="notes">**Note:** To build with the Mbed OS bare metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file:
 
       ```NOCI
       {
@@ -29,5 +29,6 @@
           "target_overrides": {
               "*": {
       ```
+   </span>
 
 1. Press the board's reset button. The LED blinks.

--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -23,7 +23,7 @@
 
     1. **NOTE** To build with the Mbed OS Bare Metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file as in the following snippet:
 
-      ```JSON
+      ```NOCI
       {
           "requires": ["bare-metal"],
           "target_overrides": {

--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -15,10 +15,19 @@
 
        ```console
        $ mbed compile --target K64F --toolchain ARM --flash
-       ```  
+       ```
 
    The `--flash` argument automatically flashes the compiled program onto your board if it is connected to your computer.
 
    <span class="tips">**Tip:** You can get the name of the board plugged into your computer by running `mbed detect`, and you can get a full list of supported toolchains and targets by running the `mbed compile --supported` command.</span>
+
+    1. **NOTE** To build with the Mbed OS Bare Metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file as in the following snippet:
+
+      ```JSON
+      {
+          "requires": ["bare-metal"],
+          "target_overrides": {
+              "*": {
+      ```
 
 1. Press the board's reset button. The LED blinks.

--- a/docs/tutorials/quickstart/example_walkthrough.md
+++ b/docs/tutorials/quickstart/example_walkthrough.md
@@ -10,45 +10,7 @@ The default baud rate, or speed, for this application is set to `9600`. You can 
 
 <span class="tips">**Tip:** You can find more information on the Mbed OS configuration tools and serial communication in Mbed OS in the [related links section](#related-links).</span>
 
-The output transmits the following block at the blinking LED frequency (actual values may vary depending on your target, build profile and toolchain):
-
-```
-=============================== SYSTEM INFO  ================================
-Mbed OS Version: 999999
-CPU ID: 0x410fc241
-Compiler ID: 2
-Compiler Version: 60300
-RAM0: Start 0x20000000 Size: 0x30000
-RAM1: Start 0x1fff0000 Size: 0x10000
-ROM0: Start 0x0 Size: 0x100000
-================= CPU STATS =================
-Idle: 98% Usage: 2%
-================ HEAP STATS =================
-Current heap: 1096
-Max heap size: 1096
-================ THREAD STATS ===============
-ID: 0x20001eac
-Name: main_thread
-State: 2
-Priority: 24
-Stack Size: 4096
-Stack Space: 3296
-
-ID: 0x20000f5c
-Name: idle_thread
-State: 1
-Priority: 1
-Stack Size: 512
-Stack Space: 352
-
-ID: 0x20000f18
-Name: timer_thread
-State: 3
-Priority: 40
-Stack Size: 768
-Stack Space: 664
-
-```
+The output transmits the system, CPU, heap, and thread information. Note that if you are building with the Mbed OS Bare Metal profile that you will not get thread information.
 
 #### Understanding the output
 

--- a/docs/tutorials/quickstart/example_walkthrough.md
+++ b/docs/tutorials/quickstart/example_walkthrough.md
@@ -10,7 +10,9 @@ The default baud rate, or speed, for this application is set to `9600`. You can 
 
 <span class="tips">**Tip:** You can find more information on the Mbed OS configuration tools and serial communication in Mbed OS in the [related links section](#related-links).</span>
 
-The output transmits the system, CPU, heap, and thread information. Note that if you are building with the Mbed OS Bare Metal profile that you will not get thread information.
+The output transmits the system, CPU, heap and thread information. 
+
+<span class="notes">**Note:** If you are building with the Mbed OS bare metal profile, you will not get thread information.</span>
 
 #### Understanding the output
 

--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -27,6 +27,15 @@ Alternatively, you may select the import button on the top left hand side of the
 
     <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/online_compile_button.png)</span>
 
+    1. **NOTE** To build with the Mbed OS Bare Metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file as in the following snippet:
+
+    ```JSON
+    {
+        "requires": ["bare-metal"],
+        "target_overrides": {
+            "*": {
+    ```
+
 1. Open the folder where the executable file was downloaded, and then click and drag (or copy and paste) the file to your Mbed board's USB device folder.
 
 1. Press the board's reset button.

--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -29,7 +29,7 @@ Alternatively, you may select the import button on the top left hand side of the
 
     1. **NOTE** To build with the Mbed OS Bare Metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file as in the following snippet:
 
-    ```JSON
+    ```NOCI
     {
         "requires": ["bare-metal"],
         "target_overrides": {

--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -27,7 +27,7 @@ Alternatively, you may select the import button on the top left hand side of the
 
     <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/online_compile_button.png)</span>
 
-    1. **NOTE** To build with the Mbed OS Bare Metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file as in the following snippet:
+    <span class="notes">**Note:** To build with the Mbed OS bare metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file:
 
     ```NOCI
     {
@@ -35,6 +35,7 @@ Alternatively, you may select the import button on the top left hand side of the
         "target_overrides": {
             "*": {
     ```
+   </span>
 
 1. Open the folder where the executable file was downloaded, and then click and drag (or copy and paste) the file to your Mbed board's USB device folder.
 


### PR DESCRIPTION
Add Bare Metal build profile instructions to the quick start. Additionally remove hardcoded expected serial output. The serial output is not updated each release and is liable to change. As such I've removed until we have a method to automatically update the output each patch release.
