### PR TITLE
docs: I2CSlave API: Add feature check to example code

### DIFF
--- a/docs/api/drivers/I2CSlave.md
+++ b/docs/api/drivers/I2CSlave.md
@@ -15,6 +15,10 @@ Try this example to see how an I2C responder works.
 ```c++ TODO
 #include <mbed.h>
 
+#if !DEVICE_I2CSLAVE
+  #error [NOT_SUPPORTED] I2C Slave is not supported
+#endif
+
 I2CSlave slave(p9, p10);
 
 int main() {


### PR DESCRIPTION
Add pre-processor feature check to the example code so that
it's easier for the user to know if the feature is enabled
on the platform under test