### PR TITLE
Correct command line for listing supported exporters

### DIFF
--- a/docs/tools/toolchains/export_to_third_party.md
+++ b/docs/tools/toolchains/export_to_third_party.md
@@ -57,7 +57,7 @@ has the same flags as if you had compiled with:
 
 For a complete list of supported export toolchains, you can run:
 
-    $ mbed export -h
+    $ mbed export --supported ides
 
 ### Before you export
 


### PR DESCRIPTION
The command line included is valid since 5.5.0.