### PR TITLE
Removed PR template from docs

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -141,33 +141,6 @@ A contribution containing a breaking change is the most difficult PR to get merg
 
 Release: major
 
-### Pull request template
-
-Below is a good example of a pull request:
-
-```
-Fix deep sleep locking bug
-
-# Description
-
-Fix problems that could leave deep sleep locked unintentionally, along with adding tests to verify this behavior is fixed.
-
-Tested locally with two targets and all toolchains.
-
-You can see test results [here](just an example).
-
-# Pull request type
-
-    [X] Fix
-    [ ] Refactor
-    [ ] Target update
-    [ ] Functionality change
-    [ ] Docs update
-    [ ] Test update
-    [ ] Breaking change
-
-```
-
 ### GitHub pull requests workflow
 
 Each pull request goes through the following workflow:


### PR DESCRIPTION
We have this: https://github.com/ARMmbed/mbed-os/blob/master/.github/pull_request_template.md

Do we a duplicate in the docs that then also needs to be maintained?

(For reference, this was brought up by @mrcoulter45 when creating https://github.com/ARMmbed/mbed-os/pull/9895#issue-257229865)