### PR TITLE
Modifications to build profile documentation

### DIFF
--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,6 +1,6 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__. These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you may select the __build profile__ by passing your desired build profile, by name or path, to the __--profile__ argument.
+Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__.  The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you may select the __build profile__ by passing your desired build profile, by name or path, to the `--profile` argument.
 
 ### Develop
 
@@ -34,9 +34,8 @@ These flags stored in the JSON file may also be merged with other JSON files of 
 
 #### JSON build profile format
 
-The __build profiles__ are implemented as JSON files with the root object representing toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
-
-Each toolchain to be supported is represented by a child object in the JSON root object. Each child object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+The __build profiles__ are JSON files with the root object containing key-value pairs for each supported toolchain, such as `GCC_ARM`.
+Each key, representing the toolchain, contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,6 +1,6 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you may select the build profile by passing your desired build profile, by name or path, to the --profile argument. You can also specify custom- or user-defined build profiles by giving the path to the JSON file defining the build profile.
+Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__. These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you may select the __build profile__ by passing your desired build profile, by name or path, to the __--profile__ argument.
 
 ### Develop
 
@@ -28,9 +28,9 @@ Arm Mbed OS 5 defines three collections of toolchain flags used during the build
 
 ### User-defined build profile
 
-As mentioned above, the __build profile__ defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
+As mentioned above, the __build profile__ defines the set of flags that is guaranteed to be passed to the underlying compiler suite. You can also create custom or user-defined __build profile__ using a JSON file acording to the __build profile__ format mentioned in [JSON build profile format](#JSON-build-profile-format).
 
-These flags are stored in a JSON file that may be merged with other JSON files of the same structure.
+These flags stored in the JSON file may also be merged with other JSON files of the same structure.
 
 #### JSON build profile format
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -26,7 +26,7 @@ Arm Mbed OS 5 defines three build configurations, each of which is known as a `b
    - Debugger is likely to drop connection.
    - Breaks the local file system on the [Mbed interface](../introduction/index.html) on some boards.
 
-### User-defined
+### User-defined `build profile`
 
 As mentioned above, the `build profile` defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,8 +1,8 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 supports three primary build profiles: *develop*, *debug* and *release*. The Online Compiler uses the *develop* profile. When building from Arm Mbed CLI, you can select a profile by adding the `--profile <profile>` flag. You can specify custom user-defined profiles by giving the path to the profile.
+Arm Mbed OS 5 pre-defines three build configurations which is basically a collection of toolchain flags used during build, and we call them `build profile`. These are *develop*, *debug* and *release*. The Online Compiler uses the *develop*. When building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`**build profile** `name>` flag. You can also specify custom/user-defined configurations by giving the path to the JSON file defining the build configuration.
 
-### Develop profile
+### Develop
 
 - Small and fast code.
 - Full error information. For example, asserts have file name and line number.
@@ -11,32 +11,32 @@ Arm Mbed OS 5 supports three primary build profiles: *develop*, *debug* and *rel
     * Debugger is likely to drop connection.
     * Breaks the local file system on the [Arm Mbed interface](../introduction/index.html) on some boards.
 
-### Debug profile
+### Debug
 
-- Largest and slowest profile.
+- Largest and slowest performance.
 - Full error information. For example, asserts have file name and line number.
 - Easy to step through code with a debugger.
 - Disabled sleep mode.
 
-### Release profile
+### Release
 
-- Smallest profile and still fast.
+- Smallest codesize and still fast.
 - Minimal error information.
 - Chip goes to sleep when going idle:
     - Debugger is likely to drop connection.
     - Breaks the local file system on the [Mbed interface](../introduction/index.html) on some boards.
 
-### User defined profiles
+### User-defined
 
-A toolchain or build system profile is a set of flags that is guaranteed to be passed to the underlying compiler suite.
+As mentioned above `build profile` defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
 
 These flags are stored in a JSON file that may be merged with other JSON files of the same structure.
 
-#### JSON toolchain profile format
+#### JSON `build profile` format
 
-The JSON object that represents a toolchain profile is a dictionary mapping from toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
+The JSON object that represents a toolchain configuration is a dictionary mapping from toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
 
-The structure is as follows: each toolchain supported by a toolchain profile has a dictionary in the root dictionary. This dictionary contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+The structure is as follows: each toolchain to be supported has a dictionary in the root dictionary. This dictionary contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 
@@ -50,7 +50,7 @@ The required flag types are:
 
 #### Example
 
-An example of a toolchain profile:
+An example of a `build profile`:
 
 ```json
 {
@@ -89,7 +89,7 @@ An example of a toolchain profile:
 }
 ```
 
-From this toolchain profile, we can tell that:
+For the above example, we can tell that:
 
 - `GCC_ARM`, `ARM` and `IAR` compiler suites are supported.
 - The `ARM` C and C++ compilers will be using optimization level `-O3`.

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,6 +1,7 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 defines three build configurations, each of which is known as a `build profile`. These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When  building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`**build profile** `name>` flag. You can also specify custom- or user-defined configurations by giving the path to the JSON file defining the build configuration.
+Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profile__.
+These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`__build profile__ `name>` flag. You can also specify custom- or user-defined configurations by giving the path to the JSON file defining the build configuration.
 
 ### Develop
 
@@ -28,15 +29,15 @@ Arm Mbed OS 5 defines three build configurations, each of which is known as a `b
 
 ### User-defined build profile
 
-As mentioned above, the `build profile` defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
+As mentioned above, the __build profile__ defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
 
 These flags are stored in a JSON file that may be merged with other JSON files of the same structure.
 
 #### JSON build profile format
 
-The JSON object that represents a toolchain configuration is a dictionary mapping from toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
+The JSON object that represents toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, like `-O3`.
 
-The structure is as follows: each toolchain to be supported has a dictionary in the root dictionary. This dictionary contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+The structure is as follows: each toolchain to be supported has an object in the root object. This object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 
@@ -50,7 +51,7 @@ The required flag types are:
 
 #### Example
 
-An example of a `build profile`:
+An example of a __build profile__:
 
 ```json
 {

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,7 +1,6 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profile__.
-These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`__build profile__ `name>` flag. You can also specify custom- or user-defined configurations by giving the path to the JSON file defining the build configuration.
+Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__. These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`__build profile__ `name>` flag. You can also specify custom- or user-defined configurations by giving the path to the JSON file defining the build configuration.
 
 ### Develop
 
@@ -37,7 +36,7 @@ These flags are stored in a JSON file that may be merged with other JSON files o
 
 The JSON object that represents toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, like `-O3`.
 
-The structure is as follows: each toolchain to be supported has an object in the root object. This object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+Each toolchain to be supported has an object in the root object. This object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 
@@ -90,10 +89,10 @@ An example of a __build profile__:
 }
 ```
 
-For the above example, we can tell that:
+In the above example, you can tell that:
 
 - `GCC_ARM`, `ARM` and `IAR` compiler suites are supported.
-- The `ARM` C and C++ compilers will be using optimization level `-O3`.
-- The `IAR` linker will skip dynamic initialization.
+- The `ARM` C and C++ compilers use optimization level `-O3`.
+- The `IAR` linker skips dynamic initialization.
 
 And so on.

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -26,7 +26,7 @@ Arm Mbed OS 5 defines three build configurations, each of which is known as a `b
    - Debugger is likely to drop connection.
    - Breaks the local file system on the [Mbed interface](../introduction/index.html) on some boards.
 
-### User-defined `build profile`
+### User-defined build profile
 
 As mentioned above, the `build profile` defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -28,7 +28,7 @@ Arm Mbed OS 5 defines three collections of toolchain flags used during the build
 
 ### User-defined build profile
 
-As mentioned above, the __build profile__ defines the set of flags that is guaranteed to be passed to the underlying compiler suite. You can also create custom or user-defined __build profile__ using a JSON file acording to the __build profile__ format mentioned in [JSON build profile format](#JSON-build-profile-format).
+As mentioned above, the __build profile__ defines the set of flags that is guaranteed to be passed to the underlying compiler suite. You can also create a custom or user-defined __build profile__ using a JSON file acording to the __build profile__ format mentioned in [JSON build profile format](#JSON-build-profile-format).
 
 These flags stored in the JSON file may also be merged with other JSON files of the same structure.
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,6 +1,6 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__. These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`__build profile__ `name>` flag. You can also specify custom- or user-defined configurations by giving the path to the JSON file defining the build configuration.
+Arm Mbed OS 5 defines three collections of toolchain flags used during the build. These are __build profiles__. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When building from Arm Mbed CLI, you may select the build profile by passing your desired build profile, by name or path, to the --profile argument. You can also specify custom- or user-defined build profiles by giving the path to the JSON file defining the build profile.
 
 ### Develop
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -34,8 +34,7 @@ These flags stored in the JSON file may also be merged with other JSON files of 
 
 #### JSON build profile format
 
-The __build profiles__ are JSON files with the root object containing key-value pairs for each supported toolchain, such as `GCC_ARM`.
-Each key, representing the toolchain, contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+The __build profiles__ are JSON files with the root object containing key-value pairs for each supported toolchain, such as `GCC_ARM`. Each key is a toolchain name and every value contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -34,9 +34,9 @@ These flags are stored in a JSON file that may be merged with other JSON files o
 
 #### JSON build profile format
 
-The JSON object that represents toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, like `-O3`.
+The JSON object that represents toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
 
-Each toolchain to be supported has an object in the root object. This object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+Each toolchain to be supported is represented by a child object in the root object. Each child object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -28,9 +28,9 @@ Arm Mbed OS 5 defines three collections of toolchain flags used during the build
 
 ### User-defined build profile
 
-As mentioned above, the __build profile__ defines the set of flags that is guaranteed to be passed to the underlying compiler suite. You can also create a custom or user-defined __build profile__ using a JSON file acording to the __build profile__ format mentioned in [JSON build profile format](#JSON-build-profile-format).
+As mentioned above, the __build profile__ defines the set of flags that is passed to the underlying compiler suite. You can also create a custom or user-defined __build profile__ using a JSON file according to the __build profile__ format mentioned in [JSON build profile format](#JSON-build-profile-format).
 
-These flags stored in the JSON file may also be merged with other JSON files of the same structure.
+These flags stored in the JSON file are merged with other JSON files of the same structure when multiple `--profile` arguments are passed on the command line.
 
 #### JSON build profile format
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -1,6 +1,6 @@
 <h2 id="build-profiles">Build profiles</h2>
 
-Arm Mbed OS 5 pre-defines three build configurations which is basically a collection of toolchain flags used during build, and we call them `build profile`. These are *develop*, *debug* and *release*. The Online Compiler uses the *develop*. When building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`**build profile** `name>` flag. You can also specify custom/user-defined configurations by giving the path to the JSON file defining the build configuration.
+Arm Mbed OS 5 defines three build configurations, each of which is known as a `build profile`. These are collections of toolchain flags used during the build. The three build profiles are *develop*, *debug* and *release*. The Mbed Online Compiler uses the *develop* build profile. When  building from Arm Mbed CLI, you can select the build configuration by adding the `--profile <`**build profile** `name>` flag. You can also specify custom- or user-defined configurations by giving the path to the JSON file defining the build configuration.
 
 ### Develop
 
@@ -8,8 +8,8 @@ Arm Mbed OS 5 pre-defines three build configurations which is basically a collec
 - Full error information. For example, asserts have file name and line number.
 - Hard to follow code flow when using a debugger.
 - Chip goes to sleep when idle:
-    * Debugger is likely to drop connection.
-    * Breaks the local file system on the [Arm Mbed interface](../introduction/index.html) on some boards.
+   - Debugger is likely to drop connection.
+   - Breaks the local file system on the [Arm Mbed interface](../introduction/index.html) on some boards.
 
 ### Debug
 
@@ -20,19 +20,19 @@ Arm Mbed OS 5 pre-defines three build configurations which is basically a collec
 
 ### Release
 
-- Smallest codesize and still fast.
+- Smallest code size and still fast.
 - Minimal error information.
 - Chip goes to sleep when going idle:
-    - Debugger is likely to drop connection.
-    - Breaks the local file system on the [Mbed interface](../introduction/index.html) on some boards.
+   - Debugger is likely to drop connection.
+   - Breaks the local file system on the [Mbed interface](../introduction/index.html) on some boards.
 
 ### User-defined
 
-As mentioned above `build profile` defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
+As mentioned above, the `build profile` defines the set of flags that is guaranteed to be passed to the underlying compiler suite.
 
 These flags are stored in a JSON file that may be merged with other JSON files of the same structure.
 
-#### JSON `build profile` format
+#### JSON build profile format
 
 The JSON object that represents a toolchain configuration is a dictionary mapping from toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
 

--- a/docs/tools/CLI/build_profiles.md
+++ b/docs/tools/CLI/build_profiles.md
@@ -34,9 +34,9 @@ These flags are stored in a JSON file that may be merged with other JSON files o
 
 #### JSON build profile format
 
-The JSON object that represents toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
+The __build profiles__ are implemented as JSON files with the root object representing toolchain configurations for mapping each supported toolchains, such as `GCC_ARM`, to their flags, such as `-O3`.
 
-Each toolchain to be supported is represented by a child object in the root object. Each child object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
+Each toolchain to be supported is represented by a child object in the JSON root object. Each child object contains a mapping from a flag type to a list of flags that should be passed to the corresponding part of the compiler suite.
 
 The required flag types are:
 


### PR DESCRIPTION
Modifications to build profile documentation to explicitly capture the fact that this is build-profile and not just any profile. This helps us create other profiles for other purposes like bare-metal.