### PR TITLE
Remove example from psa_attestation.md

### DIFF
--- a/docs/api/security/psa_attestation.md
+++ b/docs/api/security/psa_attestation.md
@@ -46,9 +46,13 @@ The token might also include data about the distinct software components on the 
 
 In the current implementation, a bootloader does not exist in single and dual V7; therefore, we have provided temporary hardcoded boot status data claims in the `attestation_bootloader_data.c` file, including `HW version`, `Boot seed`, and some `Software components` entries. `Security lifecycle` should also be part of the boot status, but in the current implementation, it is provided by calling the `psa_security_lifecycle_state()` API directly.
 
-### PSA initial attestation class reference
+### PSA initial attestation reference
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/group___p_s_a-_attestation.html)
+
+### PSA initial attestation example
+
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-attestation/blob/attestation_example)](https://github.com/ARMmbed/mbed-os-example-attestation/blob/attestation_example/main.cpp)
 
 ### Related content
 

--- a/docs/api/security/psa_attestation.md
+++ b/docs/api/security/psa_attestation.md
@@ -7,7 +7,9 @@ The initial attestation service creates a token that contains a fixed set of dev
 The PSA initial attestation service is based on the TF-M attestation service, which is available in the [TF-M repository]( https://git.trustedfirmware.org/trusted-firmware-m.git/).
 
 ### Specification
+
 The initial attestation service exposes the following PSA interfaces:
+
 ```
 enum psa_attest_err_t
 psa_initial_attest_get_token(const uint8_t *challenge_obj,
@@ -48,10 +50,6 @@ In the current implementation, a bootloader does not exist in single and dual V7
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/group___p_s_a-_attestation.html)
 
-### PSA initial attestation example
-
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os/blob/master/TESTS/psa/attestation)](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/psa/attestation/main.cpp)
-
 ### Related content
 
-* [PSA specification](https://pages.arm.com/PSA-APIs).
+- [PSA specification](https://pages.arm.com/PSA-APIs).


### PR DESCRIPTION
Remove example because we do not link to examples in `TESTS`.