### PR TITLE
Added documentation for using ARM Compiler 5 with 5.12 release

### DIFF
--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -53,7 +53,7 @@ be able to compile with ARM Compiler 5 or you may see undefined behaviors. In ot
 
 ##### By creating a mbed_app.json to override `supported_toolchains`
 
-In this method, you can create or update your `mbed_app.json` with the following content. Note that you can still keep other entries such as `GCC_ARM` or `IAR` while overriding `supported_toolchains` as below.
+In this method, you can create or update your `mbed_app.json` with the following content. Override `supported_toolchains` as below.
 
 ```
 {

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -44,3 +44,39 @@ For more information, please see the [Online Compiler page](developing-mbed-onli
 
 You can export your project from any of our tools to third party tools. For instructions, as well as tool-specific information, see [the Exporting to third party toolchains page](exporting.html).
 
+#### Forcing compilation with ARM Compiler 5 for targets already supporting ARM Compiler 6
+
+It's possible that some developers may need to update to Mbed 5.12 release but still requires compiling with ARM Compiler 5 until they are in possession of ARM Compiler 6.
+In those cases, you may still be able to use ARM Compiler 5 depending on the target. If your target uses any ARM Compiler 6 specific binaries or code, then it may not
+be able to compile with ARM Compiler 5 or you may see undefined behaviors. In other cases, if you want to try force ARM Compiler 5 you can do so with the following options:
+
+##### By creating a mbed_app.json to override `supported_toolchains`
+
+In this method, you can create or update your `mbed_app.json` with the following content. Note that you can still keep other entries such as `GCC_ARM` or `IAR` while overriding `supported_toolchains` as below.
+
+```
+{
+  "target_overrides": {
+      "*": {
+          "target.supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"]
+      }
+  }
+}
+```
+
+##### By local modifications to `targets.json`
+
+In this method, you have to modify the `supported_toolchains` entry for your target in targets.json to remove all `ARM`, `ARMC6` entries and replace it with `ARMC5`. Note that you can still keep other entries such as `GCC_ARM` or `IAR`.
+
+See below for example:
+```
+"MY_TARGET_NAME": {
+        "supported_form_factors": [...],
+        "core": "Cortex-M4",
+        "supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"],
+        ...
+}
+```
+
+<span class="note"> **Note:** The above methods to override ARM toolchain version is made available only to enable developers migrating from ARM Compiler 5 to ARM Compiler 6. Future releases of Mbed OS may remove
+this option and thus developers are strongly encouraged to move to ARM Compiler 6.</span>

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -45,31 +45,24 @@ For more information, please see the [Online Compiler page](developing-mbed-onli
 
 You can export your project from any of our tools to third party tools. For instructions, as well as tool-specific information, see [the Exporting to third party toolchains page](exporting.html).
 
-#### Forcing compilation with ARM Compiler 5 for targets already supporting ARM Compiler 6
+<div style="background-color:#F3F3F3; text-align:left; vertical-align: middle; padding:15px 30px;"> **Note:** We encourage you to switch to Arm Compiler 6 soon because we will deprecate Arm Compiler 5 support in the future. However, if you need to update to Mbed OS 5.12 but still require compiling with Arm Compiler 5 until you are in possession of Arm Compiler 6, we provide methods to override the Arm toolchain version. If you do this, your target may not be able to compile with Arm Compiler 5, or you may see undefined behaviors.
 
-It's possible that some developers may need to update to Mbed 5.12 release but still requires compiling with ARM Compiler 5 until they are in possession of ARM Compiler 6.
-In those cases, you may still be able to use ARM Compiler 5 depending on the target. If your target uses any ARM Compiler 6 specific binaries or code, then it may not
-be able to compile with ARM Compiler 5 or you may see undefined behaviors. In other cases, if you want to try force ARM Compiler 5 you can do so with the following options:
+To force Arm Compiler 5, you can use the following options:
 
-##### By creating a mbed_app.json to override `supported_toolchains`
-
-In this method, you can create or update your `mbed_app.json` with the following content. Override `supported_toolchains` as below.
+- Create or update your `mbed_app.json` with:
 
 ```
 {
   "target_overrides": {
       "*": {
-          "target.supported_toolchains": ["ARMC5"]
+          "target.supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"]
       }
   }
 }
 ```
 
-##### By local modifications to `targets.json`
+- Modify the `supported_toolchains` entry in targets.json to replace all `ARM`, `ARMC6` entries with `ARMC5`: 
 
-In this method, you have to modify the `supported_toolchains` entry for your target in targets.json to remove all `ARM`, `ARMC6` entries and replace it with `ARMC5`. Note that you can still keep other entries such as `GCC_ARM` or `IAR`.
-
-See below for example:
 ```
 "MY_TARGET_NAME": {
         "supported_form_factors": [...],
@@ -78,5 +71,4 @@ See below for example:
         ...
 }
 ```
-
-<span class="note"> **Note:** The above methods to override ARM toolchain version is made available only to enable developers migrating from ARM Compiler 5 to ARM Compiler 6. We encourage developers to make plans to switch to ARM Compiler 6 soon, as we plan to deprecate ARM Compiler 5 support in the future and this migration would ensure that your software is compatible with it. </span>
+</div> 

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -59,7 +59,7 @@ In this method, you can create or update your `mbed_app.json` with the following
 {
   "target_overrides": {
       "*": {
-          "target.supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"]
+          "target.supported_toolchains": ["ARMC5"]
       }
   }
 }

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -39,13 +39,17 @@ The Mbed Online Compiler is our in-house IDE and should be familiar to anyone wh
 
 For more information, please see the [Online Compiler page](developing-mbed-online-compiler.html).
 
+<span class="note"> **Note:** Arm Compiler 6 is the default ARM toolchain for Mbed OS developmet. Most Mbed OS platforms are already compatible with Arm Compiler 6. Some existing targets still supporting Arm Compiler 5 will also be migrated to ARM Compiler 6 in the future. Please be aware that you must use Arm Compiler 6 for future development, and we will validate all code contributions to Mbed OS with Arm Compiler 6. </span>
+
 ##### Third party development tools
 
 You can export your project from any of our tools to third party tools. For instructions, as well as tool-specific information, see [the Exporting to third party toolchains page](exporting.html).
 
-<div style="background-color:#F3F3F3; text-align:left; vertical-align: middle; padding:15px 30px;"> **Note:** Arm Compiler 6 is the default ARM toolchain for Mbed OS development. Most Mbed OS platforms are already compatible with Arm Compiler 6. Some existing targets still supporting Arm Compiler 5 will also be migrated to ARM Compiler 6 in the future. Please be aware that you must use Arm Compiler 6 for future development, and we will validate all code contributions to Mbed OS with Arm Compiler 6. We encourage you to switch to Arm Compiler 6 soon because we will deprecate Arm Compiler 5 support in the future. However, if you need to update to Mbed OS 5.12 but still require compiling with Arm Compiler 5 until you are in possession of Arm Compiler 6, we provide methods to override the Arm toolchain version. If you do this, your target may not be able to compile with Arm Compiler 5, or you may see undefined behaviors.
+<div style="background-color:#F3F3F3; text-align:left; vertical-align: middle; padding:15px 30px;"> **Note:** We encourage you to switch to Arm Compiler 6 soon because we will deprecate Arm Compiler 5 support in the future. However, if you need to update to Mbed OS 5.12 but still require compiling with Arm Compiler 5 until you are in possession of Arm Compiler 6, we provide methods to override the Arm toolchain version. If you do this, your target may not be able to compile with Arm Compiler 5, or you may see undefined behaviors.
 
-To force Arm Compiler 5, you can create or update your `mbed_app.json` with:
+To force Arm Compiler 5, you can use the following options:
+
+- Create or update your `mbed_app.json` with:
 
 ```
 {
@@ -54,6 +58,17 @@ To force Arm Compiler 5, you can create or update your `mbed_app.json` with:
           "target.supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"]
       }
   }
+}
+```
+
+- Modify the `supported_toolchains` entry in targets.json to replace all `ARM`, `ARMC6` entries with `ARMC5`: 
+
+```
+"MY_TARGET_NAME": {
+        "supported_form_factors": [...],
+        "core": "Cortex-M4",
+        "supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"],
+        ...
 }
 ```
 </div> 

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -21,7 +21,8 @@ We created the Mbed command-line tool (Mbed CLI), a Python-based tool, specifica
 
 Mbed OS 5 can be built with various toolchains. The currently supported versions are:
 
-- [Arm compiler 6.11](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
+- [Arm compiler 6.11 (default ARM toolchain)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
+- [Arm compiler 5.06 update 6 (to be deprecated in the future)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads).
 - [GNU Arm Embedded version  6 (6-2017-q1-update)](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
 - [IAR Embedded Workbench 8.32.1](https://www.iar.com/iar-embedded-workbench/tools-for-arm/arm-cortex-m-edition/).
 
@@ -78,5 +79,4 @@ See below for example:
 }
 ```
 
-<span class="note"> **Note:** The above methods to override ARM toolchain version is made available only to enable developers migrating from ARM Compiler 5 to ARM Compiler 6. Future releases of Mbed OS may remove
-this option and thus developers are strongly encouraged to move to ARM Compiler 6.</span>
+<span class="note"> **Note:** The above methods to override ARM toolchain version is made available only to enable developers migrating from ARM Compiler 5 to ARM Compiler 6. We encourage developers to make plans to switch to ARM Compiler 6 soon, as we plan to deprecate ARM Compiler 5 support in the future and this migration would ensure that your software is compatible with it. </span>

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -49,7 +49,7 @@ You can export your project from any of our tools to third party tools. For inst
 
 To force Arm Compiler 5, you can use the following options:
 
-- Create or update your `mbed_app.json` with:
+- Create or update your `mbed_app.json` as below. This is the recommended method for applications to use ARM Compiler 5.
 
 ```
 {
@@ -61,7 +61,7 @@ To force Arm Compiler 5, you can use the following options:
 }
 ```
 
-- Modify the `supported_toolchains` entry in targets.json to replace all `ARM`, `ARMC6` entries with `ARMC5`: 
+- For porting a target that cannot use Arm Compiler 6 at this time, modify the `supported_toolchains` entry in targets.json to replace all `ARM`, `ARMC6` entries with `ARMC5` as below.  
 
 ```
 "MY_TARGET_NAME": {

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -49,7 +49,7 @@ You can export your project from any of our tools to third party tools. For inst
 
 To force Arm Compiler 5, you can use the following options:
 
-- Create or update your `mbed_app.json` as below. This is the recommended method for applications to use ARM Compiler 5.
+- Create or update your `mbed_app.json` as below. This is the recommended method for applications to use Arm Compiler 5.
 
 ```
 {
@@ -61,7 +61,7 @@ To force Arm Compiler 5, you can use the following options:
 }
 ```
 
-- For porting a target that cannot use Arm Compiler 6 at this time, modify the `supported_toolchains` entry in targets.json to replace all `ARM`, `ARMC6` entries with `ARMC5` as below.  
+- For porting a target that cannot use Arm Compiler 6 at this time, modify the `supported_toolchains` entry in `targets.json` to replace all `ARM` and `ARMC6` entries with `ARMC5`:  
 
 ```
 "MY_TARGET_NAME": {

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -21,8 +21,8 @@ We created the Mbed command-line tool (Mbed CLI), a Python-based tool, specifica
 
 Mbed OS 5 can be built with various toolchains. The currently supported versions are:
 
-- [Arm compiler 6.11 (default ARM toolchain)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
-- [Arm compiler 5.06 update 6 (to be deprecated in the future)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads).
+- [Arm Compiler 6.11 (default ARM toolchain)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
+- [Arm Compiler 5.06 update 6 (to be deprecated in the future)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads).
 - [GNU Arm Embedded version  6 (6-2017-q1-update)](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
 - [IAR Embedded Workbench 8.32.1](https://www.iar.com/iar-embedded-workbench/tools-for-arm/arm-cortex-m-edition/).
 

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -39,17 +39,13 @@ The Mbed Online Compiler is our in-house IDE and should be familiar to anyone wh
 
 For more information, please see the [Online Compiler page](developing-mbed-online-compiler.html).
 
-<span class="note"> **Note:** Arm Compiler 6 is the default ARM toolchain for Mbed OS developmet. Most Mbed OS platforms are already compatible with Arm Compiler 6. Some existing targets still supporting Arm Compiler 5 will also be migrated to ARM Compiler 6 in the future. Please be aware that you must use Arm Compiler 6 for future development, and we will validate all code contributions to Mbed OS with Arm Compiler 6. </span>
-
 ##### Third party development tools
 
 You can export your project from any of our tools to third party tools. For instructions, as well as tool-specific information, see [the Exporting to third party toolchains page](exporting.html).
 
-<div style="background-color:#F3F3F3; text-align:left; vertical-align: middle; padding:15px 30px;"> **Note:** We encourage you to switch to Arm Compiler 6 soon because we will deprecate Arm Compiler 5 support in the future. However, if you need to update to Mbed OS 5.12 but still require compiling with Arm Compiler 5 until you are in possession of Arm Compiler 6, we provide methods to override the Arm toolchain version. If you do this, your target may not be able to compile with Arm Compiler 5, or you may see undefined behaviors.
+<div style="background-color:#F3F3F3; text-align:left; vertical-align: middle; padding:15px 30px;"> **Note:** Arm Compiler 6 is the default ARM toolchain for Mbed OS development. Most Mbed OS platforms are already compatible with Arm Compiler 6. Some existing targets still supporting Arm Compiler 5 will also be migrated to ARM Compiler 6 in the future. Please be aware that you must use Arm Compiler 6 for future development, and we will validate all code contributions to Mbed OS with Arm Compiler 6. We encourage you to switch to Arm Compiler 6 soon because we will deprecate Arm Compiler 5 support in the future. However, if you need to update to Mbed OS 5.12 but still require compiling with Arm Compiler 5 until you are in possession of Arm Compiler 6, we provide methods to override the Arm toolchain version. If you do this, your target may not be able to compile with Arm Compiler 5, or you may see undefined behaviors.
 
-To force Arm Compiler 5, you can use the following options:
-
-- Create or update your `mbed_app.json` with:
+To force Arm Compiler 5, you can create or update your `mbed_app.json` with:
 
 ```
 {
@@ -58,17 +54,6 @@ To force Arm Compiler 5, you can use the following options:
           "target.supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"]
       }
   }
-}
-```
-
-- Modify the `supported_toolchains` entry in targets.json to replace all `ARM`, `ARMC6` entries with `ARMC5`: 
-
-```
-"MY_TARGET_NAME": {
-        "supported_form_factors": [...],
-        "core": "Cortex-M4",
-        "supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"],
-        ...
 }
 ```
 </div> 


### PR DESCRIPTION
This is documentation addition to capture how a developer can force ARM Compiler 5 with targets
already moved to ARM Compiler 6 with 5.12 release. 