### PR TITLE
Change default build profile to bare-metal

### DIFF
--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -21,12 +21,9 @@
 
    <span class="tips">**Tip:** You can get the name of the board plugged into your computer by running `mbed detect`, and you can get a full list of supported toolchains and targets by running the `mbed compile --supported` command.</span>
 
-   <span class="notes">**Note:** To build with the Mbed OS bare metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file:</span>
+   <span class="notes">**Note:** The Blinky example is configured to build with the BareMetal profile by default. To enable the RTOS and other Mbed OS libraries, remove the following line from `mbed_app.json`:</span>
    ```NOCI
-      {
           "requires": ["bare-metal"],
-          "target_overrides": {
-              "*": {
    ```
 
 1. Press the board's reset button. The LED blinks.

--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -21,7 +21,7 @@
 
    <span class="tips">**Tip:** You can get the name of the board plugged into your computer by running `mbed detect`, and you can get a full list of supported toolchains and targets by running the `mbed compile --supported` command.</span>
 
-   <span class="notes">**Note:** The Blinky example is configured to build with the BareMetal profile by default. To enable the RTOS and other Mbed OS libraries, remove the following line from `mbed_app.json`:</span>
+   <span class="notes">**Note:** The Blinky example is configured to build with the bare metal profile by default. To enable the RTOS and other Mbed OS libraries, remove the following line from `mbed_app.json`:</span>
    ```NOCI
           "requires": ["bare-metal"],
    ```

--- a/docs/tutorials/quickstart/example_walkthrough.md
+++ b/docs/tutorials/quickstart/example_walkthrough.md
@@ -10,9 +10,9 @@ The default baud rate, or speed, for this application is set to `9600`. You can 
 
 <span class="tips">**Tip:** You can find more information on the Mbed OS configuration tools and serial communication in Mbed OS in the [related links section](#related-links).</span>
 
-The output transmits the system, CPU, and heap information. 
+The output transmits the system, CPU and heap information. 
 
-<span class="notes">**Note:** The Blinky example by default is built with the BareMetal build profile which disables the RTOS. If you build with a standard profile you will also get Thread information. To remove the BareMetal profile, remove `"requires": ["bare-metal"],` from the `mbed_app.json` file.</span>
+<span class="notes">**Note:** The Blinky example by default is built with the bare metal build profile, which disables the RTOS. If you build with a standard profile, you also see Thread information. To remove the bare metal profile, remove `"requires": ["bare-metal"],` from the `mbed_app.json` file.</span>
 
 #### Understanding the output
 
@@ -57,7 +57,7 @@ Percentage of runtime the device has spent awake.
 
 ##### Thread statistics
 
-**Note** These stats are only visible on full RTOS builds, disable the BareMetal profile to view these stats.
+<span class="notes">**Note:** These stats are only visible on full RTOS builds. Please disable the bare metal profile to view these stats.</span>
 
 Provides information on all running threads in the OS:
 

--- a/docs/tutorials/quickstart/example_walkthrough.md
+++ b/docs/tutorials/quickstart/example_walkthrough.md
@@ -10,9 +10,9 @@ The default baud rate, or speed, for this application is set to `9600`. You can 
 
 <span class="tips">**Tip:** You can find more information on the Mbed OS configuration tools and serial communication in Mbed OS in the [related links section](#related-links).</span>
 
-The output transmits the system, CPU, heap and thread information. 
+The output transmits the system, CPU, and heap information. 
 
-<span class="notes">**Note:** If you are building with the Mbed OS bare metal profile, you will not get thread information.</span>
+<span class="notes">**Note:** The Blinky example by default is built with the BareMetal build profile which disables the RTOS. If you build with a standard profile you will also get Thread information. To remove the BareMetal profile, remove `"requires": ["bare-metal"],` from the `mbed_app.json` file.</span>
 
 #### Understanding the output
 
@@ -56,6 +56,8 @@ Percentage of runtime the device has spent awake.
 - Maximum size the heap has ever reached (*not* the maximum size it can reach).
 
 ##### Thread statistics
+
+**Note** These stats are only visible on full RTOS builds, disable the BareMetal profile to view these stats.
 
 Provides information on all running threads in the OS:
 

--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -27,7 +27,7 @@ Alternatively, you may select the import button on the top left hand side of the
 
     <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/online_compile_button.png)</span>
 
-    <span class="notes">**Note:** The Blinky example is configured to build with the BareMetal profile by default. To enable the RTOS and other Mbed OS libraries, remove the following line from `mbed_app.json`:</span>
+    <span class="notes">**Note:** The Blinky example is configured to build with the bare metal profile by default. To enable the RTOS and other Mbed OS libraries, remove the following line from `mbed_app.json`:</span>
     ```NOCI
            "requires": ["bare-metal"],
     ```

--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -27,14 +27,10 @@ Alternatively, you may select the import button on the top left hand side of the
 
     <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/online_compile_button.png)</span>
 
-    <span class="notes">**Note:** To build with the Mbed OS bare metal profile, add `"requires": ["bare-metal"]` to the `mbed_app.json` file:</span>
+    <span class="notes">**Note:** The Blinky example is configured to build with the BareMetal profile by default. To enable the RTOS and other Mbed OS libraries, remove the following line from `mbed_app.json`:</span>
     ```NOCI
-    {
-        "requires": ["bare-metal"],
-        "target_overrides": {
-            "*": {
+           "requires": ["bare-metal"],
     ```
-
 1. Open the folder where the executable file was downloaded, and then click and drag (or copy and paste) the file to your Mbed board's USB device folder.
 
 1. Press the board's reset button.


### PR DESCRIPTION
# DO NOT MERGE
Pending example PR: https://github.com/ARMmbed/mbed-os-example-blinky/pull/163

______________________
Not to hold up this PR, but wanted to bring up an additional discussion thread while here. I was going to include it in this PR but am pending a few other things first. 

I'd like to take this opportunity to touch on https://jira.arm.com/browse/IOTDOCS-759. Blinky as it stands now is RTOS agnostic with the exception of Thread reporting. Using the RTOS (EventQueue specifically) however we can improve quite a bit on how we report the system stats. 

The general idea/quickstart flow could be:
1. Here's Blinky without an RTOS (BareMetal, no RTOS, smaller footprint and introduces BareMetal profiles as a concept. Also allows us to smoke test BM on Mbed OS PRs without Mbed OS modifications).
2. Oh, you want threads/RTOS? Remove this one line and rebuild.
3. Cool, you added the RTOS. What's next? Choose to move on and dive into Mbed OS headfirst, link to all tutorials/examples. Want us to give you walk you through developing an Mbed OS application? Here's something cool you can do by using EventQueue to cleanup your application and Main thread:
![image](https://user-images.githubusercontent.com/1060940/54061218-85c2a700-41c5-11e9-809e-74532a835822.png)

Pending talks with Anthony/webteam on how to actually handle file diffs on the docs site, will update when we hear back.