### PR TITLE
Workflow: update breaking change PR

### DIFF
--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
@@ -1,0 +1,11 @@
+<!--
+    These sections should part of the PR template for any breaking change
+-->
+
+### Brief description
+
+### Analysis of effects
+
+### Migration
+
+### Release notes

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
@@ -4,7 +4,7 @@
 
 ### Release notes
 
-#### Brief description
+#### Description
 
 #### Analysis of effects
 

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
@@ -4,8 +4,8 @@
 
 ### Release notes
 
-#### Description
+#### Reason for change
 
 #### Analysis of effects
 
-#### Migration
+#### Migration path

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
@@ -1,5 +1,5 @@
 <!--
-    These sections should part of the PR template for any breaking change
+    These sections should be part of the PR template for any breaking change.
 -->
 
 ### Release notes

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_breaking_change.md
@@ -2,10 +2,10 @@
     These sections should part of the PR template for any breaking change
 -->
 
-### Brief description
-
-### Analysis of effects
-
-### Migration
-
 ### Release notes
+
+#### Brief description
+
+#### Analysis of effects
+
+#### Migration

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
@@ -4,7 +4,7 @@
 
 ### Release notes
 
-#### Brief description
+#### Description
 
 #### Analysis of effects
 

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
@@ -2,10 +2,11 @@
     These sections should be part of the PR template for any functional change
 -->
 
-### Brief description
-
-### Analysis of effects
-
-### Migration
-
 ### Release notes
+
+#### Brief description
+
+#### Analysis of effects
+
+#### Migration
+

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
@@ -1,5 +1,5 @@
 <!--
-    These sections should be part of the PR template for any functional change
+    These sections should be part of the PR template for any functional change.
 -->
 
 ### Release notes

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
@@ -4,9 +4,10 @@
 
 ### Release notes
 
-#### Description
+#### Reason for change
 
 #### Analysis of effects
 
-#### Migration
+#### Migration path
+
 

--- a/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
+++ b/docs/reference/contributing/guidelines/pull_request_drafts/pr_functional_change.md
@@ -1,0 +1,11 @@
+<!--
+    These sections should be part of the PR template for any functional change
+-->
+
+### Brief description
+
+### Analysis of effects
+
+### Migration
+
+### Release notes

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -112,7 +112,7 @@ It must contain:
 
 <span class="notes">**Note:** We may use this content in our official release notes.</span>
 
-Pull request template addition for functional changes [here](./pull_request_drafts/pr_functional_change.md).
+For more details, please see the [pull request template addition for functional changes](./pull_request_drafts/pr_functional_change.md).
 
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.
 
@@ -151,9 +151,9 @@ It must contain:
 
 <span class="notes">**Note:** We may use this content in our official release notes.</span>
 
-Pull request template addition [here](./pull_request_drafts/pr_breaking_change.md).
+For more details, please see the [pull request template addition](./pull_request_drafts/pr_breaking_change.md).
 
-The breaking change pull requests must be approved by a project tech-lead and the Mbed OS tech lead.
+A project technical lead and the Mbed OS technical lead must approve breaking change pull requests.
 
 Release: major
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -139,6 +139,16 @@ A breaking change is any change that results in breaking user space. It should h
 
 A contribution containing a breaking change is the most difficult PR to get merged. Any breaking changes in a codebase can have a large negative impact on any users of the codebase. Breaking changes are always limited to a major version release.
 
+Every pull request with breaking change must contain a release notes section called "Release notes" to describe the changes to users.
+
+It must contain:
+
+- A brief description of changes introduced, including justification description.
+- An analysis of effects: components affected, potential consequences for users and reasons for breaking user space.
+- Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
+
+The breaking change pull requests must be approved by a project tech-lead and the Mbed OS tech lead.
+
 Release: major
 
 ### GitHub pull requests workflow

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -107,7 +107,7 @@ Every pull request changing or adding functionality must contain a release notes
 It must contain:
 
 - A brief description of changes introduced, including justification description.
-- An analysis of effects: components affected, potential consequences for users.
+- An analysis of effects: components affected and potential consequences for users.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 
 <span class="notes">**Note:** We may use this content in our official release notes.</span>

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -107,7 +107,7 @@ Every pull request changing or adding functionality must contain a release notes
 It must contain:
 
 - A brief description of changes introduced.
-- An analysis of effects: components affected, potential consequences for users and reasons for the addition or change.
+- An analysis of effects: components affected, potential consequences for users.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 
 <span class="notes">**Note:** We may use this content in our official release notes.</span>
@@ -146,7 +146,7 @@ Every pull request with breaking change must contain a release notes section cal
 It must contain:
 
 - A brief description of changes introduced, including justification description.
-- An analysis of effects: components affected, potential consequences for users and reasons for breaking user space.
+- An analysis of effects: components affected, potential consequences for users.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 
 <span class="notes">**Note:** We may use this content in our official release notes.</span>

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -106,7 +106,7 @@ Every pull request changing or adding functionality must contain a release notes
 
 It must contain:
 
-- A brief description of changes introduced.
+- A brief description of changes introduced, including justification description.
 - An analysis of effects: components affected, potential consequences for users.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -112,6 +112,8 @@ It must contain:
 
 <span class="notes">**Note:** We may use this content in our official release notes.</span>
 
+Pull request template addition for functional changes [here](./pull_request_drafts/pr_functional_change.md).
+
 We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers create the new branches by following the naming convention: "feature-" prefix.
 
 Each feature has a tech lead. This person is responsible for:
@@ -146,6 +148,10 @@ It must contain:
 - A brief description of changes introduced, including justification description.
 - An analysis of effects: components affected, potential consequences for users and reasons for breaking user space.
 - Migration guidance: actions for updating the current code. Please include code snippets to illustrate before and after the addition or change.
+
+<span class="notes">**Note:** We may use this content in our official release notes.</span>
+
+Pull request template addition [here](./pull_request_drafts/pr_breaking_change.md).
 
 The breaking change pull requests must be approved by a project tech-lead and the Mbed OS tech lead.
 


### PR DESCRIPTION
We updated functionality changes recently but left behind more important ones (assuming it should follow the same) - breaking changes.

This PR updates it, and adds also PR templates (ppl can copy it to the default PR template). I made them the same in draft (breaking change has the same release notes section template but might change during review - please leave suggestions).

@ARMmbed/mbed-os-maintainers first round reviews

