### PR TITLE
Add tag based configuration parameter splitting

### DIFF
--- a/check_tools/config-update.py
+++ b/check_tools/config-update.py
@@ -105,17 +105,19 @@ def main(file):
                     print("\t------- Tag: %s -------" % tag)
 
                     start_of_config_block = file.find('Name:', start)
-                    updated_config = str(file[ : start_of_config_block]) # + "Configuration parameters\n------------------------\n")
+                    updated_config = str(file[ : start_of_config_block])
                     for line in out.splitlines():
                         if 'Name' in line and tag in line:
                             updated_config += line
 
                             # Collect all text until next parameter name. If there's no following 'Name:' token, its the last
-                            # config option, match to 'Macros' instead to termiante the block
-                            if out.find('Name:', out.find(line) + 4) > 0:
-                                updated_config += out[out.find('\n', out.find(line)) : out.find('Name:', out.find(line) + 4)]
+                            # config option, match to 'Macros' instead to termiante the block. Offset starting index to avoid finding
+                            # the current line's 'Name:' token.
+                            eol = out.find('\n', out.find(line))
+                            if out.find('Name:', out.find(line) + len('Name:')) > 0:
+                                updated_config += out[eol : out.find('Name:', out.find(line) + len('Name:'))]
                             else:
-                                updated_config += out[out.find('\n', out.find(line)) : out.find('Macros', out.find(line) + 4)]
+                                updated_config += out[eol : out.find('Macros', out.find(line))]
 
                     updated_config += str(file[end:])
                 else:

--- a/check_tools/config-update.py
+++ b/check_tools/config-update.py
@@ -85,8 +85,8 @@ def main(file):
                 print("=================   %s   =================" % lib)
                 out = str(subprocess.check_output(["mbed", "compile", "--config", "-v", "--prefix", lib]))
 
-                # Some APIs break config optioins into logical blocks in their config files.
-                # If a tag is applied to a parameter block, only display parameter names that contains that tag
+                # Some APIs break config options into logical blocks in their config files.
+                # If a tag is applied to a parameter block, only display parameter names that contain that tag
                 # For example:
                 #   ```heap
                 #   mbed-mesh-api.heap-size
@@ -96,7 +96,7 @@ def main(file):
                 #   ......
                 #   ```
                 #
-                # On encountering a block with tag, collect the common parameter token
+                # On encountering a block with a tag, collect the common parameter token,
                 # and split the configuration list output into its components.
                 # Collect tag (if present), split <TAG> from ```<TAG> at current index
                 # Check with regex for string to cover for potential trailing whitespaces

--- a/check_tools/config-update.py
+++ b/check_tools/config-update.py
@@ -52,13 +52,10 @@ def is_string(line):
     line - string to scan
 
     Returns:
-    True if the string contains [a-z], else False
+    Match object if the string contains [a-z], else None
     """
     regexp = re.compile(r'[a-z]', re.IGNORECASE)
-    if regexp.search(line):
-        return True
-    else:
-        return False
+    return regexp.search(line)
 
 def main(file):
     file_h = open(file, 'r+')

--- a/check_tools/config-update.py
+++ b/check_tools/config-update.py
@@ -21,7 +21,7 @@ LIBRARIES BUILD
 # By default, when run from the check_tools directory, the script runs
 # through each Markdown file in `docs/reference/configuration/`. An
 # optional file or directory path may be passed in a parameter to run the
-# script on a specific file or directroy outside the default path. 
+# script on a specific file or directroy outside the default path.
 #
 # Note that you need to run this with a local copy of whichever version of
 # Mbed OS you wish to update the configuration parameters with.
@@ -44,6 +44,21 @@ def split_into_pairs(l):
     """
     for i in range(0, len(l), 2):
         yield l[i:i + 2]
+
+def is_string(line):
+    """ Determine if the provided string contains
+        alphabetical characters (case insensitive)
+    Args:
+    line - string to scan
+
+    Returns:
+    True if the string contains [a-z], else False
+    """
+    regexp = re.compile(r'[a-z]', re.IGNORECASE)
+    if regexp.search(line):
+        return True
+    else:
+        return False
 
 def main(file):
     file_h = open(file, 'r+')
@@ -69,7 +84,44 @@ def main(file):
                 lib = blocks[i].split('Name: ')[1].split('.')[0]
                 print("=================   %s   =================" % lib)
                 out = str(subprocess.check_output(["mbed", "compile", "--config", "-v", "--prefix", lib]))
-                file = file[:start+4] + out[:out.index("Macros") - 1] + file[end:]
+
+                # Some APIs break config optioins into logical blocks in their config files.
+                # If a tag is applied to a parameter block, only display parameter names that contains that tag
+                # For example:
+                #   ```heap
+                #   mbed-mesh-api.heap-size
+                #       ...
+                #   mbed-mesh-api.heap-stat-info
+                #       ..
+                #   ......
+                #   ```
+                #
+                # On encountering a block with tag, collect the common parameter token
+                # and split the configuration list output into its components.
+                # Collect tag (if present), split <TAG> from ```<TAG> at current index
+                # Check with regex for string to cover for potential trailing whitespaces
+                tag = file[start : file.find('\n', start)].split('`')[-1]
+                if is_string(tag):
+                    print("\t------- Tag: %s -------" % tag)
+
+                    start_of_config_block = file.find('Name:', start)
+                    updated_config = str(file[ : start_of_config_block]) # + "Configuration parameters\n------------------------\n")
+                    for line in out.splitlines():
+                        if 'Name' in line and tag in line:
+                            updated_config += line
+
+                            # Collect all text until next parameter name. If there's no following 'Name:' token, its the last
+                            # config option, match to 'Macros' instead to termiante the block
+                            if out.find('Name:', out.find(line) + 4) > 0:
+                                updated_config += out[out.find('\n', out.find(line)) : out.find('Name:', out.find(line) + 4)]
+                            else:
+                                updated_config += out[out.find('\n', out.find(line)) : out.find('Macros', out.find(line) + 4)]
+
+                    updated_config += str(file[end:])
+                else:
+                    updated_config = str(file[:start+4] + out[:out.index("Macros") - 1] + file[end:])
+
+                file = updated_config
 
         # Originally added for debugging purposes, catch and display exceptions before
         # continuing without exiting to provide a complete list of errors found


### PR DESCRIPTION
https://github.com/ARMmbed/mbed-os-5-docs/pull/981 (mesh configuration file) logically splits up the `mbed_mesh_api` configuration parameters to improve readability. The automatic config update script could not handle this previously. 

Now (as in the case of the Mesh API), if there is a uniquely common tag in how each segment is split up, the script all lump common tags together if requested by including the tag in the configuration page's markdown as in the following example (see test and test2 tags):

```
### This is a configuration parameter doc page!
Here's how you use the `test` parameters in the lib1 library.

'''test
Configuration parameters
--------------------------
Name: lib1.test-a
    Description: I'm just a test
    ....
Name: lib1.test-b
    Description: I'm another test parameter
    ....
....
'''

### This is another section
Here's how you use the `test2` parameters in the lib1 library.

'''test2
Configuration parameters
--------------------------
Name: lib1.test2-a
    Description: I'm just a test
    ....
Name: lib1.test2-b
    Description: I'm another test parameter
    ....
....
'''

```