### PR TITLE
Update uvision version to 6

### DIFF
--- a/docs/tutorials/debug/keil_uvision.md
+++ b/docs/tutorials/debug/keil_uvision.md
@@ -23,7 +23,7 @@ To export your project to uVision, you can use either the Online Compiler or Mbe
 
     ```
     # replace K64F with your target board
-    $ mbed export -i uvision5 -m K64F
+    $ mbed export -i uvision6 -m K64F
     ```
 
 ### Starting a debug session


### PR DESCRIPTION
Since we have moved to arm compiler 6, during export the uvision version should be changed to 6. In future, we will track it based on supported toolchain instead of hardcoding a value.