### PR TITLE
Using Mbed Studio's ARMC6 with Mbed CLI

### DIFF
--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -228,15 +228,16 @@ Mbed CLI supports a setting for each toolchain path:
 | IAR EWARM Compiler | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm/bin/iccarm.exe` | `IAR_PATH` | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm`|
 | GCC Arm Embedded Compiler | `/usr/bin/arm-none-eabi-gcc` | `GCC_ARM_PATH` | `/usr/bin`|
 
-##### Using Arm Compiler 6 from Mbed Studio
+##### Using Arm Compiler 6 (from Mbed Studio)
+
 Mbed Studio comes with a free version of Arm Compiler 6 for use with Mbed OS. If you want to use Arm Compiler 6 with Mbed CLI:
 
 1. Install [Mbed Studio](https://os.mbed.com/docs/mbed-studio/latest/introduction/index.html).
 1. Configure the `ARMC6_PATH`.
 
-    For Mbed Studio 0.4.0, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
+    For Mbed Studio 0.4 and later, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
 
-1. Set the environment variable `ARMLMD_LICENSE_FILE` to the path of Mbed Studio's Arm Compiler 6 license. For Mbed Studio 0.4.0, the license is located at `./tools/ac6-license.dat`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6-license.dat`. 
+1. Set the environment variable `ARMLMD_LICENSE_FILE` to the path of Mbed Studio's Arm Compiler 6 license. For Mbed Studio 0.4 and later, the license is located at `./tools/ac6-license.dat`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6-license.dat`. 
 
     Note that this environment variable is not managed by Mbed CLI, so you must set it appropriately in your environment.
 

--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -240,11 +240,6 @@ Mbed Studio comes with a free version of Arm Compiler 6 for use with Mbed OS. If
 
     Note that this environment variable is not managed by Mbed CLI, so you must set it appropriately in your environment.
 
-
-For Mbed Studio version 0.4.0, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
-
-You must also set the environment variable `ARMLMD_LICENSE_FILE` to the path of Mbed Studio's Arm Compiler 6 license. For Mbed Studio version 0.4.0, the license is located at `./tools/ac6-license.dat`. This path is relative to the installation directory of Mbed Studio. On Windows for example, the default path is `C:\MbedStudio\tools\ac6-license.dat`. Note that this environment variable is not managed by Mbed CLI, so you must set it appropriately in your environment.
-
 #### Method 2: environment variable
 
 In addition to the manually configured compiler locations, Mbed CLI detects executables that are in paths specified by toolchain-specific environment variables.

--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -229,7 +229,17 @@ Mbed CLI supports a setting for each toolchain path:
 | GCC Arm Embedded Compiler | `/usr/bin/arm-none-eabi-gcc` | `GCC_ARM_PATH` | `/usr/bin`|
 
 ##### Using Arm Compiler 6 from Mbed Studio
-Mbed Studio comes with a free version of Arm Compiler 6 when it's used with Mbed OS. It requires configuring the `ARMC6_PATH` as well as setting an environment variable to manage the license.
+Mbed Studio comes with a free version of Arm Compiler 6 for use with Mbed OS. If you want to use Arm Compiler 6 with Mbed CLI:
+
+1. Install [Mbed Studio](https://os.mbed.com/docs/mbed-studio/latest/introduction/index.html).
+1. Configure the `ARMC6_PATH`.
+
+    For Mbed Studio 0.4.0, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
+
+1. Set the environment variable `ARMLMD_LICENSE_FILE` to the path of Mbed Studio's Arm Compiler 6 license. For Mbed Studio 0.4.0, the license is located at `./tools/ac6-license.dat`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6-license.dat`. 
+
+    Note that this environment variable is not managed by Mbed CLI, so you must set it appropriately in your environment.
+
 
 For Mbed Studio version 0.4.0, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
 

--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -228,6 +228,12 @@ Mbed CLI supports a setting for each toolchain path:
 | IAR EWARM Compiler | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm/bin/iccarm.exe` | `IAR_PATH` | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm`|
 | GCC Arm Embedded Compiler | `/usr/bin/arm-none-eabi-gcc` | `GCC_ARM_PATH` | `/usr/bin`|
 
+##### Using Arm Compiler 6 from Mbed Studio
+Mbed Studio comes with a free version of Arm Compiler 6 when it's used with Mbed OS. It requires configuring the `ARMC6_PATH` as well as setting an environment variable to manage the license.
+
+For Mbed Studio version 0.4.0, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
+
+You must also set the environment variable `ARMLMD_LICENSE_FILE` to the path of Mbed Studio's Arm Compiler 6 license. For Mbed Studio version 0.4.0, the license is located at `./tools/ac6-license.dat`. This path is relative to the installation directory of Mbed Studio. On Windows for example, the default path is `C:\MbedStudio\tools\ac6-license.dat`. Note that this environment variable is not managed by Mbed CLI, so you must set it appropriately in your environment.
 
 #### Method 2: environment variable
 

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -21,7 +21,10 @@ We created the Mbed command-line tool (Mbed CLI), a Python-based tool, specifica
 
 Mbed OS 5 can be built with various toolchains. The currently supported versions are:
 
-- [Arm Compiler 6.11 (default ARM toolchain)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6), also included in [Keil MDK 5.27](http://www2.keil.com/mdk5/).
+- Arm Compiler 6.11 (default ARM toolchain).
+  - A free version when it's used with Mbed OS is included with [Mbed Studio](https://os.mbed.com/studio/). For information on using this with Mbed CLI, please see the [After installation - configuring Mbed CLI page](../tools/after-installation-configuring-mbed-cli.html).
+  - A paid version is available as [Arm Compiler 6.11 Professional](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
+  - A paid version is also included in [Keil MDK 5.27](http://www2.keil.com/mdk5/).
 - [Arm Compiler 5.06 update 6 (to be deprecated in the future)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads).
 - [GNU Arm Embedded version  6 (6-2017-q1-update)](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
 - [IAR Embedded Workbench 8.32.1](https://www.iar.com/iar-embedded-workbench/tools-for-arm/arm-cortex-m-edition/).


### PR DESCRIPTION
This is the accompanying docs changes informing users on how to take advantage of the free Arm Compiler 6 bundled with Mbed Studio when building with Mbed CLI.

This is the corresponding OS tools change that will print a link to this encouraging users to upgrade to Arm Compiler 6: https://github.com/ARMmbed/mbed-os/pull/10193

**Reviewer notes/requests**

_For Mbed Studio folks:_ want y'all to be aware of what we're telling our users. I realize the compiler may move around in future releases. Please keep me posted and I can update this doc to match what you release, thanks!

_For docs team:_ do the fine work y'all always do :+1:

_For everyone else:_ general review and to keep you in the loop

FYI @iriark01 @AnotherButler @bulislaw @SenRamakri @thegecko @arekzaluski 

^ Lots of people but this is pretty wide reaching, thanks for taking the time to review this!