### PR TITLE
Revert "Using Mbed Studio's ARMC6 with Mbed CLI"

### DIFF
--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -228,18 +228,6 @@ Mbed CLI supports a setting for each toolchain path:
 | IAR EWARM Compiler | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm/bin/iccarm.exe` | `IAR_PATH` | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm`|
 | GCC Arm Embedded Compiler | `/usr/bin/arm-none-eabi-gcc` | `GCC_ARM_PATH` | `/usr/bin`|
 
-##### Using Arm Compiler 6 (from Mbed Studio)
-
-Mbed Studio comes with a free version of Arm Compiler 6 for use with Mbed OS. If you want to use Arm Compiler 6 with Mbed CLI:
-
-1. Install [Mbed Studio](https://os.mbed.com/docs/mbed-studio/latest/introduction/index.html).
-1. Configure the `ARMC6_PATH`.
-
-    For Mbed Studio 0.4 and later, the Arm Compiler 6 executable is located in `./tools/ac6/bin`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6\bin`.
-
-1. Set the environment variable `ARMLMD_LICENSE_FILE` to the path of Mbed Studio's Arm Compiler 6 license. For Mbed Studio 0.4 and later, the license is located at `./tools/ac6-license.dat`. This path is relative to the installation directory of Mbed Studio. On Windows, for example, the default path is `C:\MbedStudio\tools\ac6-license.dat`. 
-
-    Note that this environment variable is not managed by Mbed CLI, so you must set it appropriately in your environment.
 
 #### Method 2: environment variable
 

--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -21,10 +21,7 @@ We created the Mbed command-line tool (Mbed CLI), a Python-based tool, specifica
 
 Mbed OS 5 can be built with various toolchains. The currently supported versions are:
 
-- Arm Compiler 6.11 (default ARM toolchain).
-  - A free version when it's used with Mbed OS is included with [Mbed Studio](https://os.mbed.com/studio/). For information on using this with Mbed CLI, please see the [After installation - configuring Mbed CLI page](../tools/after-installation-configuring-mbed-cli.html).
-  - A paid version is available as [Arm Compiler 6.11 Professional](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
-  - A paid version is also included in [Keil MDK 5.27](http://www2.keil.com/mdk5/).
+- [Arm Compiler 6.11 (default ARM toolchain)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6), also included in [Keil MDK 5.27](http://www2.keil.com/mdk5/).
 - [Arm Compiler 5.06 update 6 (to be deprecated in the future)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads).
 - [GNU Arm Embedded version  6 (6-2017-q1-update)](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
 - [IAR Embedded Workbench 8.32.1](https://www.iar.com/iar-embedded-workbench/tools-for-arm/arm-cortex-m-edition/).


### PR DESCRIPTION
Reverts ARMmbed/mbed-os-5-docs#1028

@bridadan I do not think that documenting the location of the tools that we are shipping with Mbed Studio is a good idea. They are designed to be isolated and to work only with Mbed Studio.
Mbed CLI should not reuse tools that we are shipping inside of Mbed Studio. The way that it should be done is for mebd CLI installers to ship its own ARMC6.

We also can't commit to the location of tools. In fact release 0.5 (next release) is going to change tools location. It is going to be specific on each of the platform supported by Mbed Studio.