### PR TITLE
Add Mbed CLI troubleshooting doc about python dependencies

### DIFF
--- a/docs/tools/CLI/troubleshooting.md
+++ b/docs/tools/CLI/troubleshooting.md
@@ -11,4 +11,6 @@ The Mbed OS tools in this program require the following Python modules: <missing
 You can install all missing modules by running "pip install -r mbed-os/requirements.txt" in "."
 ```
 
-These dependencies are described in the [`requirements.txt`](https://github.com/ARMmbed/mbed-os/blob/master/requirements.txt) file within Mbed OS. You can read more about this requirements file and Python dependency management in the [`pip` documentation](https://pip.pypa.io/en/stable/user_guide/#requirements-files).
+This command installs all the dependencies listed in the [`requirements.txt`](https://github.com/ARMmbed/mbed-os/blob/master/requirements.txt) file within Mbed OS. 
+
+You can read more about requirements files and Python dependency management in the [`pip` documentation](https://pip.pypa.io/en/stable/user_guide/#requirements-files).

--- a/docs/tools/CLI/troubleshooting.md
+++ b/docs/tools/CLI/troubleshooting.md
@@ -3,7 +3,7 @@
 
 ### Missing Python dependencies
 
-Mbed CLI attempts to automatically installs missing Python dependencies. This step can fail if Mbed CLI does not have permission to install them. If it fails, Mbed CLI will print out a warning and a suggested command to run with the necessary permissions:
+Mbed CLI attempts to automatically install missing Python dependencies. If Mbed CLI doesn't have the necessary permissions, installation fails and Mbed CLI prints out a warning and a suggested command to run with the necessary permissions:
 
 ```
 Missing Python modules were not auto-installed.

--- a/docs/tools/CLI/troubleshooting.md
+++ b/docs/tools/CLI/troubleshooting.md
@@ -1,0 +1,14 @@
+
+## Troubleshooting
+
+### Missing Python dependencies
+
+Mbed CLI attempts to automatically installs missing Python dependencies. This step can fail if Mbed CLI does not have permission to install them. If it fails, Mbed CLI will print out a warning and a suggested command to run with the necessary permissions:
+
+```
+Missing Python modules were not auto-installed.
+The Mbed OS tools in this program require the following Python modules: <missing modules>
+You can install all missing modules by running "pip install -r mbed-os/requirements.txt" in "."
+```
+
+These dependencies are described in the [`requirements.txt`](https://github.com/ARMmbed/mbed-os/blob/master/requirements.txt) file within Mbed OS. You can read more about this requirements file and Python dependency management in the [`pip` documentation](https://pip.pypa.io/en/stable/user_guide/#requirements-files).


### PR DESCRIPTION
This resolves **IOTDOCS-666**.

This documents how to deal with missing python dependencies with Mbed CLI.

FYI @teetak01 @theotherjimmy 

@ARMmbed/mbed-docs I have attempted to add a separate "Troubleshooting" page for the "Working with Mbed CLI" section, I hope it did it right. If you'd prefer for this to be part of an existing pagewithin the docs, just let me know.