### PR TITLE
Fix default path to toolchains

### DIFF
--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -223,9 +223,9 @@ Mbed CLI supports a setting for each toolchain path:
 
 | Toolchain | Example binary location | Setting name | Example path |
 | --------- | --------- | ---------| --------- |
-| Arm Compiler 5 | `C:/Program Files/ARM_Compiler_5.06u6/bin/armcc` | `ARM_PATH` | `C:/Program Files/ARM_Compiler_5.06u6` |
-| Arm Compiler 6 | `C:/Program Files/ARM/armcc6.10/bin/armclang` | `ARMC6_PATH` | `C:/Program Files/ARM/armcc6.10/bin` |
-| IAR EWARM Compiler | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm/bin/iccarm.exe` | `IAR_PATH` | `C:/Program Files/IAR Systems/Embedded Workbench 8.2/arm`|
+| Arm Compiler 5.06u6 | `C:\Program Files\ARM_Compiler_5.06u6\bin\armcc` | `ARM_PATH` | `C:\Program Files\ARM_Compiler_5.06u6` |
+| Arm Compiler 6.11 | `C:\Program Files\ARMCompiler6.11\bin\armclang` | `ARMC6_PATH` | `C:\Program Files\ARMCompiler6.11\bin` |
+| IAR EWARM Compiler 8.32.1 | `C:\Program Files\IAR Systems\Embedded Workbench 8.2\arm\bin\iccarm.exe` | `IAR_PATH` | `C:\Program Files\IAR Systems\Embedded Workbench 8.2\arm`|
 | GCC Arm Embedded Compiler | `/usr/bin/arm-none-eabi-gcc` | `GCC_ARM_PATH` | `/usr/bin`|
 
 ##### Using Arm Compiler 6 (from Mbed Studio)
@@ -313,7 +313,7 @@ Available configurations:
 | --- | --- | --- |
 | `target` | The default target for `compile`, `test` and `export`; an alias of `mbed target`. | No default. |
 | `toolchain` | The default toolchain for `compile` and `test`; can be set through `mbed toolchain`. | No default. |
-| `ARM_PATH`, `GCC_ARM_PATH`, `IAR_PATH` | Define the paths to Arm Compiler, GCC Arm and IAR Workbench toolchains. | No default. |
+| `ARM_PATH`, `ARMC6_PATH`, `GCC_ARM_PATH`, `IAR_PATH` | Define the paths to Arm Compiler, GCC Arm and IAR Workbench toolchains. | No default. |
 | `protocol` | The default protocol used for importing or cloning programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service such as GitHub, GitLab, or Bitbucket. For more information, see [SSH keys on GitHub](https://help.github.com/articles/generating-an-ssh-key/). | Default: `https`. |
 | `depth` | The *clone* depth for importing or cloning. Applies only to *Git* repositories. Note that though this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. For more information, see [shallow clones on GitHub](https://git-scm.com/docs/git-clone). | No default. |
 | `cache` | The local path that stores small copies of the imported or cloned repositories. Mbed CLI uses it to minimize traffic and speed up future imports of the same repositories. Use `on` or `enabled` to turn on caching in the system temp path. Use `none` to turn caching off. | Default: none (disabled). |


### PR DESCRIPTION
These are simple tweaks to:
- Replace references to wrong AC6 toolchain with the correct one
- Use default and the most common path to AC6 toolchain
- Clarify version of IAR (as they use a different path name that doesn't match with the tools version)
- Adds ARMC6_PATH option

@AnotherButler 