### PR TITLE
Add tools troubleshooting doc to builder

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -889,7 +889,10 @@
                             },
                             {
                                 "path": "docs/tools/CLI/debug_builds_cli.md"
-                            }
+                            },
+                            {
+                                "path": "docs/tools/CLI/troubleshooting.md"
+                            },
                         ]
                     }
                 ]


### PR DESCRIPTION
Follow up to https://github.com/ARMmbed/mbed-os-5-docs/pull/1032.

I realized I never added the page to the docs manifest 🤦‍♂️ 

FYI @AnotherButler 