### PR TITLE
Overhaul the 'mbed compile' docs

### DIFF
--- a/docs/tools/CLI/cli-compile.md
+++ b/docs/tools/CLI/cli-compile.md
@@ -1,10 +1,28 @@
 # Compile
 
-The following section goes into detail about some of the arguments available with the `mbed compile` command. Please run `mbed compile --help` locally to get a full list of arguments.
+
+
+This section details some of the arguments available with the `mbed compile` command. Please run `mbed compile --help` to get a full list of arguments.
 
 ## Compile your application
 
-Use the `mbed compile` command to compile your code. Supply the `-m` and `-t` arguments to set your target and toolchain respectively:
+Use the `mbed compile` command to compile your code. Supply the `-m` and `-t` arguments to set your target and toolchain, respectively.
+
+To find your board's target name, use `--supported`.
+
+The valid toolchain values are:
+
+<!--does "based on environment" mean "whichever one is installed"?-->
+
+| Argument value | Toolchain |
+| --------- | --------- |
+| `ARM` | Arm Compiler 5 or Arm Compiler 6 (based on environment) |
+| `ARMC5` | Arm Compiler 5 |
+| `ARMC6` | Arm Compiler 6 |
+| `IAR` | IAR EWARM Compiler |
+| `GCC_ARM` | GNU Arm Embedded Compiler (GCC) |
+
+As an example, for the K64F and ARM Compiler:
 
 ```
 $ mbed compile -m K64F -t ARM
@@ -35,9 +53,10 @@ Total RAM memory (data + bss + heap + stack): 109096 bytes
 Total Flash memory (text + data + misc): 66014 bytes
 Image: BUILD/K64F/GCC_ARM/mbed-os-program.bin
 ```
-### Set the target
 
-You can set the default target with the `mbed target` command to avoid having to supply the `-m` argument:
+### Set default or detected target
+
+To set a default target, use the `mbed target` command with the name of your target (in this example, the K64F):
 
 ```
 $ mbed target K64F
@@ -45,27 +64,21 @@ $ mbed target K64F
 [mbed] K64F now set as default target in program "project"
 ```
 
-Mbed CLI can detect the target connected to the system and use that as the build target. Enable this behavior by setting the target to `detect` or `auto`.
-
-### Set the toolchain
-
-You can set the default target with the `mbed toolchain` command to avoid having to supply the `-t` argument:
+Alternatively, pass `detect` instead of your target name to automatically use the target already connected to your computer:
 
 ```
-$ mbed target GCC_ARM
+$ mbed target detect
+```
+
+### Set default toolchain
+
+To set a default toolchain, use the `mbed toolchain` command:
+
+```
+$ mbed toolchain GCC_ARM
 [mbed] Working path "C:\project" (program)
 [mbed] GCC_ARM now set as default toolchain in program "project"
 ```
-
-The valid toolchain values are as follows:
-
-| Argument value | Toolchain |
-| --------- | --------- |
-| `ARM` | Arm Compiler 5 or Arm Compiler 6 (based on environment) |
-| `ARMC5` | Arm Compiler 5 |
-| `ARMC6` | Arm Compiler 6 |
-| `IAR` | IAR EWARM Compiler |
-| `GCC_ARM` | GNU Arm Embedded Compiler (GCC) |
 
 ### Perform a clean build
 
@@ -75,9 +88,9 @@ To rebuild the project, use the `-c/--clean` argument:
 mbed compile -c
 ```
 
-### Flash and monitor the target with the built program
+### Flash the built program and monitor the target
 
-You can flash a connected target with the built program by adding the `-f/--flash` argument:
+You can flash the built program to the connected target by adding the `-f/--flash` argument to the `compile` command:
 
 ```
 mbed compile -f
@@ -85,13 +98,15 @@ mbed compile -f
 
 You can also read and write to the target's serial port by adding the `--sterm` argument (this can be chained with the `-f/--flash` argument):
 
+<!--missing example-->
+
 
 ## Build sources and output
 
 
 ### Source directories
 
-Mbed CLI includes the program's root directory as the source directory as well as all subdirectories. You can control what directories are used by using the `--source` argument. You can supply multiple `--source` arguments to include multiple directories:
+By default, Mbed CLI includes the program's root directory and all its subdirectories as the source directory. To control which directories are used, use the `--source` argument. You can supply multiple `--source` arguments to include multiple directories:
 
 ```
 $ mbed compile --source ./src --source ./lib
@@ -99,41 +114,47 @@ $ mbed compile --source ./src --source ./lib
 
 ### Build directory
 
-The default build directory is in the root of your project in a directory called `BUILD`. You can set the build directory `--build` argument:
+The default build directory is in the root of your project, and is called `BUILD`. You can set the build directory with the `--build` argument:
 
 ```
 $ mbed compile --build my_build
 ```
 
-### Build profiles
-
-Build profiles are used to control what arguments are passed to the compiler. For more information about build profiles, please see the [build profile documentation](../tools/build-profiles.html).
-
-The default build profile is set to `develop`, which enables debug logging. There is also a `debug` profile (for enabling debug symbols) and a `release` profile (for disabling debug logging, saving program size). This is controlled with the `--profile` argument:
-
-```
-$ mbed compile --profile debug
-```
-
 ### Build a library
+<!--this feels like it should be "building", especially since we have "build directory"; "building" makes it clearer that this is a verb, whereas the previous one was a noun-->
 
-If you wish to build a static library instead of a linked executable, you can use the `--library` argument:
+To build a static library instead of a linked executable, use the `--library` argument:
 
 ```
 $ mbed compile --library
 ```
 
-To suppress the creation of the `.a/.ar` archive (and instead leave the `.o` object files), use the `--no-archive` argument in addition to the `--library` argument. 
+To suppress the creation of the `.a/.ar` archive (and instead leave the `.o` object files), use both the `--library` and `--no-archive` arguments:
+
+<!--example please-->
+## Build profiles
+
+Build profiles control which arguments are passed to the compiler. For more information about build profiles, please see the [build profile documentation](../tools/build-profiles.html).
+
+The default build profile is `develop`, which enables debug logging. There is also a `debug` profile, which enables debug symbols, and a `release` profile that disables debug logging (to reduce the program size).
+
+To select a profile, use the `--profile` argument:
+
+```
+$ mbed compile --profile debug
+```
 
 ## Configuration system
 
-You can use `mbed compile --config` to view the configuration (use the `-v` argument to display more information):
+The Mbed OS configuration system customises compile time configuration parameters. For more info, [see the full configuration system documentation](./reference/configuration.html).
+
+To view your current configuration, use `mbed compile --config` (use the `-v` argument to display more information):
 
 ```
 $ mbed compile --config -t GCC_ARM -m K64F -v
 ```
 
-It's possible to filter the output of `mbed compile --config` by specifying one or more `--prefix` arguments for the configuration parameters that Mbed CLI displays. For example, to display only the configuration defined by the targets:
+To filter the output of `mbed compile --config`, specify one or more `--prefix` arguments for the configuration parameters that Mbed CLI displays. For example, to display only the configuration defined by the targets:
 
 ```
 $ mbed compile --config -t GCC_ARM -m K64F --prefix target
@@ -147,7 +168,7 @@ $ mbed compile --config -t GCC_ARM -m K64F --prefix target --prefix app
 
 ### Define macros
 
-Define macros when compiling by using the `-D` argument:
+To define macros when compiling, use the `-D` argument:<!--are you defining them here, or calling them? and is this the same as https://os.mbed.com/docs/mbed-os/v5.12/reference/configuration.html-->
 
 ```
 $ mbed compile -D MY_MACRO -D MY_VALUE=1

--- a/docs/tools/CLI/cli-compile.md
+++ b/docs/tools/CLI/cli-compile.md
@@ -1,11 +1,13 @@
 # Compile
 
-## Compiling your application
+The following section goes into detail about some of the arguments available with the `mbed compile` command. Please run `mbed compile --help` locally to get a full list of arguments.
 
-Use the `mbed compile` command to compile your code:
+## Compile your application
+
+Use the `mbed compile` command to compile your code. Supply the `-m` and `-t` arguments to set your target and toolchain respectively:
 
 ```
-$ mbed compile -t ARM -m K64F
+$ mbed compile -m K64F -t ARM
 Building project mbed-os-program (K64F, GCC_ARM)
 Compile: aesni.c
 Compile: blowfish.c
@@ -33,80 +35,105 @@ Total RAM memory (data + bss + heap + stack): 109096 bytes
 Total Flash memory (text + data + misc): 66014 bytes
 Image: BUILD/K64F/GCC_ARM/mbed-os-program.bin
 ```
+### Set the target
 
-The arguments for *compile* are:
-
-- `-m <MCU>` selects a target. If `detect` or `auto` parameter is passed to `-m`, then Mbed CLI detects the connected target.
-- `-t <TOOLCHAIN>` selects a toolchain defined in `mbed_settings.py`. The value can be `ARM` (Arm Compiler 6 or ARM Compiler 5), `ARMC5` (ARM Compiler 5), `ARMC6` (Arm Compiler 6), `GCC_ARM` (GNU Arm Embedded) or `IAR` (IAR Embedded Workbench for Arm).
-   <span class="notes">**Note**: `mbed compile -t ARM` selects the Arm Compiler major version based on the Arm architecture version of your target and `supported_toolchains` configuration.
-   Please see `supported_toolchains` in [Adding and configuring targets](../reference/adding-and-configuring-targets.html) and `Compiler versions` in [Arm Mbed tools](../tools/index.html) for more information on toolchain configuration and usage.</span>
-- `--source <SOURCE>` selects the source directory. The default is `.` (the current directory). You can specify multiple source locations, even outside the program tree. Find more details about the `--source` switch in the [build rules documentation](../reference/mbed-os-build-rules.html).
-- `--build <BUILD>` selects the build directory. Default: `BUILD/` inside your program root.
-   <span class="notes">**Note**: `mbed compile` ignores the current build directory; creating multiple build directories leads to errors.</span>
-- `--stats-depth <DEPTH>` summarizes memory statistics within the table printed after linking, the CSV map file and the JSON map file for paths with depth greater than `DEPTH`. Default: `2`.
-- `--profile <PATH_TO_BUILD_PROFILE>` selects a path to a build profile configuration file. Example: `debug`. See the dedicated [build profile documentation](../tools/build-profiles.html) for more detail.
-- `--library` compiles the code as a [static `.a/.ar` library](#compiling-static-libraries).
-- `--no-archive` suppresses the creation of `.a/.ar` files created by `--library`, producing many `.o` files instead.
-   <span class="notes">**Note**: This option does nothing without `--library`.</span>
-- `--config` inspects the runtime compile configuration (see below).
-- `-S` or `--supported` shows a matrix of the supported targets and toolchains.
-- `-f` or `--flash` flashes/programs a connected target after successful compile.
-- `-c ` builds from scratch, a clean build or rebuild.
-- `-j <jobs>` controls the compile processes on your machine. The default value is 0, which infers the number of processes from the number of cores on your machine. You can use `-j 1` to trigger a sequential compile of source code.
-- `-v` or `--verbose` shows verbose diagnostic output.
-- `-vv` or `--very_verbose` shows very verbose diagnostic output.
-
-You can find the compiled binary, ELF image, memory usage and link statistics in the `BUILD` subdirectory of your program.
-
-For more information, please see [our build profiles](../tools/build-profiles.html) pages.
-
-## Compiling static libraries
-
-You can build a static library of your code by adding the `--library` argument to `mbed compile`. Static libraries are useful when you want to build multiple applications from the same Mbed OS codebase without having to recompile for every application. To achieve this:
-
-1. Build a static library for `mbed-os`.
-2. Compile multiple applications or tests against the static library:
+You can set the default target with the `mbed target` command to avoid having to supply the `-m` argument:
 
 ```
-$ mbed compile -t ARM -m K64F --library --no-archive --source=mbed-os --build=../mbed-os-build
-Building library mbed-os (K64F, ARM)
-[...]
-Completed in: (47.4)s
-
-$ mbed compile -t ARM -m K64F --source=mbed-os/TESTS/integration/basic --source=../mbed-os-build --build=../basic-out
-Building project basic (K64F, ARM)
-Compile: main.cpp
-Link: basic
-Elf2Bin: basic
-Image: ../basic-out/basic.bin
-
-$ mbed compile -t ARM -m K64F --source=mbed-os/TESTS/integration/threaded_blinky --source=../mbed-os-build --build=..\/hreaded_blinky-out
-Building project threaded_blinky (K64F, ARM)
-Compile: main.cpp
-Link: threaded_blinky
-Elf2Bin: threaded_blinky
-Image: ../threaded_blinky-out/threaded_blinky.bin
+$ mbed target K64F
+[mbed] Working path "C:\project" (program)
+[mbed] K64F now set as default target in program "project"
 ```
 
-## The compile configuration system
+Mbed CLI can detect the target connected to the system and use that as the build target. Enable this behavior by setting the target to `detect` or `auto`.
 
-The [compile configuration system](../tools/compile.html) provides a flexible mechanism for configuring the Mbed program, its libraries and the build target.
+### Set the toolchain
 
-### Inspecting the configuration
-
-You can use `mbed compile --config` to view the configuration:
+You can set the default target with the `mbed toolchain` command to avoid having to supply the `-t` argument:
 
 ```
-$ mbed compile --config -t GCC_ARM -m K64F
+$ mbed target GCC_ARM
+[mbed] Working path "C:\project" (program)
+[mbed] GCC_ARM now set as default toolchain in program "project"
 ```
 
-To display more verbose information about the configuration parameters, use `-v`:
+The valid toolchain values are as follows:
+
+| Argument value | Toolchain |
+| --------- | --------- |
+| `ARM` | Arm Compiler 5 or Arm Compiler 6 (based on environment) |
+| `ARMC5` | Arm Compiler 5 |
+| `ARMC6` | Arm Compiler 6 |
+| `IAR` | IAR EWARM Compiler |
+| `GCC_ARM` | GNU Arm Embedded Compiler (GCC) |
+
+### Perform a clean build
+
+To rebuild the project, use the `-c/--clean` argument:
+
+```
+mbed compile -c
+```
+
+### Flash and monitor the target with the built program
+
+You can flash a connected target with the built program by adding the `-f/--flash` argument:
+
+```
+mbed compile -f
+```
+
+You can also read and write to the target's serial port by adding the `--sterm` argument (this can be chained with the `-f/--flash` argument):
+
+
+## Build sources and output
+
+
+### Source directories
+
+Mbed CLI includes the program's root directory as the source directory as well as all subdirectories. You can control what directories are used by using the `--source` argument. You can supply multiple `--source` arguments to include multiple directories:
+
+```
+$ mbed compile --source ./src --source ./lib
+```
+
+### Build directory
+
+The default build directory is in the root of your project in a directory called `BUILD`. You can set the build directory `--build` argument:
+
+```
+$ mbed compile --build my_build
+```
+
+### Build profiles
+
+Build profiles are used to control what arguments are passed to the compiler. For more information about build profiles, please see the [build profile documentation](../tools/build-profiles.html).
+
+The default build profile is set to `develop`, which enables debug logging. There is also a `debug` profile (for enabling debug symbols) and a `release` profile (for disabling debug logging, saving program size). This is controlled with the `--profile` argument:
+
+```
+$ mbed compile --profile debug
+```
+
+### Build a library
+
+If you wish to build a static library instead of a linked executable, you can use the `--library` argument:
+
+```
+$ mbed compile --library
+```
+
+To suppress the creation of the `.a/.ar` archive (and instead leave the `.o` object files), use the `--no-archive` argument in addition to the `--library` argument. 
+
+## Configuration system
+
+You can use `mbed compile --config` to view the configuration (use the `-v` argument to display more information):
 
 ```
 $ mbed compile --config -t GCC_ARM -m K64F -v
 ```
 
-It's possible to filter the output of `mbed compile --config` by specifying one or more prefixes for the configuration parameters that Mbed CLI displays. For example, to display only the configuration defined by the targets:
+It's possible to filter the output of `mbed compile --config` by specifying one or more `--prefix` arguments for the configuration parameters that Mbed CLI displays. For example, to display only the configuration defined by the targets:
 
 ```
 $ mbed compile --config -t GCC_ARM -m K64F --prefix target
@@ -118,39 +145,10 @@ You may use `--prefix` more than once. To display only the application and targe
 $ mbed compile --config -t GCC_ARM -m K64F --prefix target --prefix app
 ```
 
-### Compile-time customizations
+### Define macros
 
-#### Macros
-
-You can specify macros in your command-line using the -D option. For example:
+Define macros when compiling by using the `-D` argument:
 
 ```
-$ mbed compile -t GCC_ARM -m K64F -c -DUVISOR_PRESENT
+$ mbed compile -D MY_MACRO -D MY_VALUE=1
 ```
-
-#### Compile in debug mode
-
-To compile in debug mode (as opposed to the default *develop* mode), use `--profile debug` in the compile command-line:
-
-```
-$ mbed compile -t GCC_ARM -m K64F --profile debug
-```
-
-
-### Automate toolchain and target selection
-
-Using `mbed target <target>` and `mbed toolchain <toolchain>`, you can set the default target and toolchain for your program. You won't have to specify these every time you compile or generate IDE project files.
-
-You can also use `mbed target detect`, which detects the connected target board and uses it as a parameter to every subsequent compile and export.
-
-### Update programs and libraries
-
-You can update programs and libraries on your local machine so that they pull in changes from the remote sources (Git or Mercurial).
-
-As with any Mbed CLI command, `mbed update` uses the current directory as a working context. Before calling `mbed update`, you should change your working directory to the one you want to update. For example, if you're updating `mbed-os`, use `cd mbed-os` before you begin updating.
-
-<span class="tips">**Tip: Synchronizing library references:** Before triggering an update, you may want to synchronize any changes that you've made to the program structure by running `mbed sync`, which updates the necessary library references and removes the invalid ones.</span>
-
-#### Protect against overwriting local changes
-
-The update command fails if there are changes in your program or library that `mbed update` could overwrite. This is by design. Mbed CLI does not run operations that would result in overwriting uncommitted local changes. If you get an error, take care of your local changes (commit or use one of the options below), and then rerun `mbed update`.

--- a/docs/tools/CLI/cli-compile.md
+++ b/docs/tools/CLI/cli-compile.md
@@ -1,10 +1,8 @@
-# Compile
-
-
+# Compiling mbed compile --library --no-archive
 
 This section details some of the arguments available with the `mbed compile` command. Please run `mbed compile --help` to get a full list of arguments.
 
-## Compile your application
+## Compiling your application
 
 Use the `mbed compile` command to compile your code. Supply the `-m` and `-t` arguments to set your target and toolchain, respectively.
 
@@ -12,17 +10,15 @@ To find your board's target name, use `--supported`.
 
 The valid toolchain values are:
 
-<!--does "based on environment" mean "whichever one is installed"?-->
-
 | Argument value | Toolchain |
 | --------- | --------- |
-| `ARM` | Arm Compiler 5 or Arm Compiler 6 (based on environment) |
+| `ARM` | Arm Compiler 5 or Arm Compiler 6 (whichever is installed) |
 | `ARMC5` | Arm Compiler 5 |
 | `ARMC6` | Arm Compiler 6 |
 | `IAR` | IAR EWARM Compiler |
 | `GCC_ARM` | GNU Arm Embedded Compiler (GCC) |
 
-As an example, for the K64F and ARM Compiler:
+As an example, for the K64F and Arm Compiler:
 
 ```
 $ mbed compile -m K64F -t ARM
@@ -54,7 +50,7 @@ Total Flash memory (text + data + misc): 66014 bytes
 Image: BUILD/K64F/GCC_ARM/mbed-os-program.bin
 ```
 
-### Set default or detected target
+### Setting a default target
 
 To set a default target, use the `mbed target` command with the name of your target (in this example, the K64F):
 
@@ -70,7 +66,7 @@ Alternatively, pass `detect` instead of your target name to automatically use th
 $ mbed target detect
 ```
 
-### Set default toolchain
+### Setting a default toolchain
 
 To set a default toolchain, use the `mbed toolchain` command:
 
@@ -80,7 +76,7 @@ $ mbed toolchain GCC_ARM
 [mbed] GCC_ARM now set as default toolchain in program "project"
 ```
 
-### Perform a clean build
+### Performing a clean build
 
 To rebuild the project, use the `-c/--clean` argument:
 
@@ -88,7 +84,7 @@ To rebuild the project, use the `-c/--clean` argument:
 mbed compile -c
 ```
 
-### Flash the built program and monitor the target
+### Flashing the built program and monitor the target
 
 You can flash the built program to the connected target by adding the `-f/--flash` argument to the `compile` command:
 
@@ -100,9 +96,7 @@ You can also read and write to the target's serial port by adding the `--sterm` 
 
 <!--missing example-->
 
-
 ## Build sources and output
-
 
 ### Source directories
 
@@ -114,14 +108,13 @@ $ mbed compile --source ./src --source ./lib
 
 ### Build directory
 
-The default build directory is in the root of your project, and is called `BUILD`. You can set the build directory with the `--build` argument:
+The default build directory is in the root of your project and is called `BUILD`. You can set the build directory with the `--build` argument:
 
 ```
 $ mbed compile --build my_build
 ```
 
-### Build a library
-<!--this feels like it should be "building", especially since we have "build directory"; "building" makes it clearer that this is a verb, whereas the previous one was a noun-->
+### Building a library
 
 To build a static library instead of a linked executable, use the `--library` argument:
 
@@ -131,7 +124,8 @@ $ mbed compile --library
 
 To suppress the creation of the `.a/.ar` archive (and instead leave the `.o` object files), use both the `--library` and `--no-archive` arguments:
 
-<!--example please-->
+   `mbed compile --library --no-archive`
+
 ## Build profiles
 
 Build profiles control which arguments are passed to the compiler. For more information about build profiles, please see the [build profile documentation](../tools/build-profiles.html).
@@ -146,7 +140,7 @@ $ mbed compile --profile debug
 
 ## Configuration system
 
-The Mbed OS configuration system customises compile time configuration parameters. For more info, [see the full configuration system documentation](./reference/configuration.html).
+The Mbed OS configuration system customizes compile time configuration parameters. For more information, please see [the full configuration system documentation](../reference/configuration.html).
 
 To view your current configuration, use `mbed compile --config` (use the `-v` argument to display more information):
 
@@ -166,9 +160,9 @@ You may use `--prefix` more than once. To display only the application and targe
 $ mbed compile --config -t GCC_ARM -m K64F --prefix target --prefix app
 ```
 
-### Define macros
+### Defining macros
 
-To define macros when compiling, use the `-D` argument:<!--are you defining them here, or calling them? and is this the same as https://os.mbed.com/docs/mbed-os/v5.12/reference/configuration.html-->
+To define macros when compiling, use the `-D` argument:
 
 ```
 $ mbed compile -D MY_MACRO -D MY_VALUE=1

--- a/docs/tools/CLI/cli-compile.md
+++ b/docs/tools/CLI/cli-compile.md
@@ -94,7 +94,9 @@ mbed compile -f
 
 You can also read and write to the target's serial port by adding the `--sterm` argument (this can be chained with the `-f/--flash` argument):
 
-<!--missing example-->
+```
+mbed compile -f --sterm
+```
 
 ## Build sources and output
 

--- a/docs/tools/CLI/cli-create.md
+++ b/docs/tools/CLI/cli-create.md
@@ -119,7 +119,7 @@ $ mbed import https://github.com/ARMmbed/mbed-os-example-blinky#mbed-os-5.11.0
 [mbed] Adding library "mbed-os" from "https://github.com/ARMmbed/mbed-os" at rev #6a0a86538c0b
 ```
 
-You can specify which version to import using `#` followed by a commit hash, a branch name, or a tag name. This syntax also works with an SSH link to a repository:
+You can specify which version to import using `#` followed by a commit hash, a branch name or a tag name. This syntax also works with an SSH link to a repository:
 
 ```
 $ mbed import git@github.com:ARMmbed/mbed-os-example-blinky.git#mbed-os-5.11.0

--- a/docs/tools/CLI/cli-create.md
+++ b/docs/tools/CLI/cli-create.md
@@ -119,7 +119,13 @@ $ mbed import https://github.com/ARMmbed/mbed-os-example-blinky#mbed-os-5.11.0
 [mbed] Adding library "mbed-os" from "https://github.com/ARMmbed/mbed-os" at rev #6a0a86538c0b
 ```
 
-You can specify which version to import using `#` followed by a commit hash, a branch name, or a tag name. If you do not provide any of these (nor the `#` character), the latest commit on the `master` branch will be imported.
+You can specify which version to import using `#` followed by a commit hash, a branch name, or a tag name. This syntax also works with an SSH link to a repository:
+
+```
+$ mbed import git@github.com:ARMmbed/mbed-os-example-blinky.git#mbed-os-5.11.0
+```
+
+If you do not provide any of these (nor the `#` character), the latest commit on the `master` branch will be imported.
 
 A project's default name is the last part of the URL (excluding `#` and its value). In the example above, the imported program's project folder is `mbed-os-example-blinky`. To specify a different name, supply it as an extra positional argument in the `mbed import` command. For example, to name your project `my-blinky`, run:
 


### PR DESCRIPTION
Addresses part of IOTDOCS-778. This removes the wall o' arguments from the `mbed compile` page and moves them into a more example-based format.