### PR TITLE
PSA Crypto porting guide updates for Mbed OS 5.13

### DIFF
--- a/docs/porting/psa/crypto.md
+++ b/docs/porting/psa/crypto.md
@@ -17,7 +17,7 @@ To run these tests, make sure make sure your target configuration is set:
 
 1.  `extra_labels` contains the label `PSA`. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L1451) or [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7694).
 1.  `MBEDTLS_PSA_CRYPTO_C` macro is enabled. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L1454) or [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7697).
-1. `MBEDTLS_ENTROPY_NV_SEED` macro is enabled in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7673).
+1. `MBEDTLS_ENTROPY_NV_SEED` and `MBEDTLS_PSA_ENTROPY_INJECTION` macros are enabled in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7673).
 1. `MBEDTLS_PLATFORM_NV_SEED_READ_MACRO` macro is set to `mbed_default_seed_read` in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7674).
 1. `MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO` macro is set to `mbed_default_seed_write` in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7674).
 

--- a/docs/porting/psa/crypto.md
+++ b/docs/porting/psa/crypto.md
@@ -13,13 +13,19 @@ Mbed OS currently provides two tests for Mbed Crypto:
 - A test for initialization of the Mbed Crypto module.
 - A test for entropy injection feature.
 
-To run these tests, make sure make sure your target configuration is set:
+To run these tests, make sure make sure your target configuration is set as
+follows:
 
-1.  `extra_labels` contains the label `PSA`. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L1451) or [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7694).
-1.  `MBEDTLS_PSA_CRYPTO_C` macro is enabled. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L1454) or [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7697).
-1. `MBEDTLS_ENTROPY_NV_SEED` and `MBEDTLS_PSA_ENTROPY_INJECTION` macros are enabled in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7673).
-1. `MBEDTLS_PLATFORM_NV_SEED_READ_MACRO` macro is set to `mbed_default_seed_read` in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7674).
-1. `MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO` macro is set to `mbed_default_seed_write` in the SPE if the device does not have TRNG or if you want the entropy injection test. Please see an example using the [Future Sequana](https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json#L7674).
+1.  `extra_labels` contains the label `PSA`. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L1485) or [LPC55S69](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L2129).
+1.  The `MBEDTLS_PSA_CRYPTO_C` macro is enabled for NSPE or SPE targets. Please see an example using the [LPC55S69](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L2124).
+
+Additionally, if the device does not have a TRNG or if you'd like to run the
+entropy injection test, ensure the Mbed TLS configuration is set on the SPE as
+follows:
+
+1. The `MBEDTLS_ENTROPY_NV_SEED` and `MBEDTLS_PSA_ENTROPY_INJECTION` macros are enabled.
+1. The `MBEDTLS_PLATFORM_NV_SEED_READ_MACRO` macro is set to `mbed_default_seed_read`.
+1. The `MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO` macro is set to `mbed_default_seed_write`.
 
 ## Compile and run
 

--- a/docs/porting/psa/crypto.md
+++ b/docs/porting/psa/crypto.md
@@ -13,15 +13,12 @@ Mbed OS currently provides two tests for Mbed Crypto:
 - A test for initialization of the Mbed Crypto module.
 - A test for entropy injection feature.
 
-To run these tests, make sure make sure your target configuration is set as
-follows:
+To run these tests, make sure make sure your target configuration is set:
 
 1.  `extra_labels` contains the label `PSA`. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L1485) or [LPC55S69](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L2129).
 1.  The `MBEDTLS_PSA_CRYPTO_C` macro is enabled for NSPE or SPE targets. Please see an example using the [LPC55S69](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L2124).
 
-Additionally, if the device does not have a TRNG or if you'd like to run the
-entropy injection test, ensure the Mbed TLS configuration is set on the SPE as
-follows:
+Additionally, if the device does not have a TRNG or if you'd like to run the entropy injection test, ensure the Mbed TLS configuration is set on the SPE:
 
 1. The `MBEDTLS_ENTROPY_NV_SEED` and `MBEDTLS_PSA_ENTROPY_INJECTION` macros are enabled.
 1. The `MBEDTLS_PLATFORM_NV_SEED_READ_MACRO` macro is set to `mbed_default_seed_read`.

--- a/docs/porting/psa/crypto.md
+++ b/docs/porting/psa/crypto.md
@@ -15,8 +15,8 @@ Mbed OS currently provides two tests for Mbed Crypto:
 
 To run these tests, make sure make sure your target configuration is set:
 
-1.  `extra_labels` contains the label `PSA`. Please see an example using the [K64F](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L1485) or [LPC55S69](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L2129).
-1.  The `MBEDTLS_PSA_CRYPTO_C` macro is enabled for NSPE or SPE targets. Please see an example using the [LPC55S69](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.13.0-rc2/targets/targets.json#L2124).
+1.  `extra_labels` contains the label `PSA`.
+1.  The `MBEDTLS_PSA_CRYPTO_C` macro is enabled for NSPE or SPE targets.
 
 Additionally, if the device does not have a TRNG or if you'd like to run the entropy injection test, ensure the Mbed TLS configuration is set on the SPE:
 


### PR DESCRIPTION
Update the PSA Crypto porting guide for Mbed OS 5.13, as well as other improvements.