### PR TITLE
Add C++14 content to common_issues.md

### DIFF
--- a/docs/tutorials/debug/common_issues.md
+++ b/docs/tutorials/debug/common_issues.md
@@ -22,7 +22,7 @@ If you are using an old version of Mbed CLI, you may see compile-time errors. Ma
 
 Mbed OS 5 can be built with various toolchains. Make sure you are using the latest versions of the toolchains. You can find the currently supported versions on [our tools page](../tools/index.html).
 
-The default profiles for the GCC and Arm toolchains now select C++14 and C11. Some applications may fail to compile because they use constructs that were valid in C++98 but not in C++14. This may also apply to your applications if you are migrating from older Mbed OS versions that used IAR 7. To fix these common compatibilitiy issues:
+The default toolchain profiles now select C++14 and C11. Some applications that worked with older versions of Mbed OS may fail to compile because they use constructs that were valid in C++98 but not in C++14. To fix these common compatibility issues:
 
 - A space is required when a macro follows a string literal, for example in C99-style `printf` formats:
    

--- a/docs/tutorials/debug/common_issues.md
+++ b/docs/tutorials/debug/common_issues.md
@@ -26,7 +26,7 @@ The default profiles for the GCC and Arm toolchains now select C++14 and C11. So
 
 - A space is required when a macro follows a string literal, for example in C99-style `printf` formats:
    
-   ```C++
+   ```C++ NOCI
        uint32_t val;
        printf("val = %"PRIu32, val); // Not valid in C++11
        printf("val = %" PRIu32, val); // OK
@@ -36,7 +36,7 @@ The default profiles for the GCC and Arm toolchains now select C++14 and C11. So
    
 - Initializer lists cannot have implicit narrowing conversions:
    
-   ```C++
+   ```C++ NOCI
        uint32_t x;
        uint8_t array1[] = { x }; // Not valid in C++11
        uint8_t array2[] = { 0xffff }; // Not valid in C++11

--- a/docs/tutorials/debug/common_issues.md
+++ b/docs/tutorials/debug/common_issues.md
@@ -22,6 +22,30 @@ If you are using an old version of Mbed CLI, you may see compile-time errors. Ma
 
 Mbed OS 5 can be built with various toolchains. Make sure you are using the latest versions of the toolchains. You can find the currently supported versions on [our tools page](../tools/index.html).
 
+The default profiles for the GCC and Arm toolchains now select C++14 and C11. Some applications may fail to compile because they use constructs that were valid in C++98 but not in C++14. This may also apply to your applications if you are migrating from older Mbed OS versions that used IAR 7. To fix these common compatibilitiy issues:
+
+- A space is required when a macro follows a string literal, for example in C99-style `printf` formats:
+   
+   ```C++
+       uint32_t val;
+       printf("val = %"PRIu32, val); // Not valid in C++11
+       printf("val = %" PRIu32, val); // OK
+   ```
+   
+   Without the space, C++11 interprets it as being a request for a user-defined "PRIu32-type" string literal.
+   
+- Initializer lists cannot have implicit narrowing conversions:
+   
+   ```C++
+       uint32_t x;
+       uint8_t array1[] = { x }; // Not valid in C++11
+       uint8_t array2[] = { 0xffff }; // Not valid in C++11
+       uint8_t array3[] = { x & 0xff }; // Not valid in C++11
+       uint8_t array4[] = { (uint8_t) x }; // OK
+       uint8_t array5[] = { static_cast<uint8_t>(x) }; // OK
+       uint8_t array6[] = { 0xffff & 0xff }; // OK (because it's a compile-time constant that fits)
+   ```
+
 ### Compiler licenses
 
 If using Keil MDK (Arm Compiler) or IAR, make sure you have a license installed. For example, [MDK-Lite](http://www.keil.com/arm/mdk.asp) has a 32 KB restriction on code size.


### PR DESCRIPTION
Add section about C++14 mode being the default and the implications of that.