### PR TITLE
Add a link to USB tests README in porting guide

### DIFF
--- a/docs/porting/target/usb.md
+++ b/docs/porting/target/usb.md
@@ -49,3 +49,4 @@ The Mbed OS HAL provides a set of conformance tests for the HAL USBPhy API. You 
 ```
 mbed test -t <toolchain> -m <target> -n mbed-os-tests-usb_device-*
 ```
+For **setup instructions**, known issues and more information about USB tests, see the [README](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/usb_device/README.md).

--- a/docs/porting/target/usb.md
+++ b/docs/porting/target/usb.md
@@ -49,4 +49,4 @@ The Mbed OS HAL provides a set of conformance tests for the HAL USBPhy API. You 
 ```
 mbed test -t <toolchain> -m <target> -n mbed-os-tests-usb_device-*
 ```
-For **setup instructions**, known issues and more information about USB tests, see the [README](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/usb_device/README.md).
+For **setup instructions**, known issues and more information about USB tests, please see the [README](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/usb_device/README.md).

--- a/docs/porting/target/usb.md
+++ b/docs/porting/target/usb.md
@@ -49,4 +49,5 @@ The Mbed OS HAL provides a set of conformance tests for the HAL USBPhy API. You 
 ```
 mbed test -t <toolchain> -m <target> -n mbed-os-tests-usb_device-*
 ```
+
 For **setup instructions**, known issues and more information about USB tests, please see the [README](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/usb_device/README.md).


### PR DESCRIPTION
Update the USB porting guide with a reference to a top-level README file for the USB tests.