### PR TITLE
Add ResetReason and Watchdog driver docs

### DIFF
--- a/docs/api/drivers/ResetReason.md
+++ b/docs/api/drivers/ResetReason.md
@@ -1,12 +1,16 @@
 ## ResetReason
 
-Use the ResetReason interface to access hardware reset reason registers in a portable fashion.
+Use the ResetReason interface to determine the cause of the last system reset in a portable fashion.
+
+When the system restarts, the reason for the restart is contained in the system registers at boot time in a platform specific manner. This API provides a generic method of fetching the reason for the restart.
 
 ### ResetReason class reference
 
 [![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.8/mbed-os-api-doxy/classmbed_1_1_resetreason.html)
 
 ### ResetReason example
+
+Check the cause of the last system reset.
 
 ```c++
 #include "mbed.h"

--- a/docs/api/drivers/ResetReason.md
+++ b/docs/api/drivers/ResetReason.md
@@ -6,7 +6,7 @@ You can use the ResetReason interface to determine the cause of the last system 
 
 ### ResetReason class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.8/mbed-os-api-doxy/classmbed_1_1_resetreason.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/_reset_reason_8h_source.html)
 
 ### ResetReason example
 

--- a/docs/api/drivers/ResetReason.md
+++ b/docs/api/drivers/ResetReason.md
@@ -6,7 +6,7 @@ You can use the ResetReason interface to determine the cause of the last system 
 
 ### ResetReason class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/_reset_reason_8h_source.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_reset_reason.html)
 
 ### ResetReason example
 

--- a/docs/api/drivers/ResetReason.md
+++ b/docs/api/drivers/ResetReason.md
@@ -1,8 +1,8 @@
 ## ResetReason
 
-Use the ResetReason interface to determine the cause of the last system reset in a portable fashion.
+When the system restarts, the system registers contain the reason for the restart at boot time in a platform specific manner. This API provides a generic method of fetching the reason for the restart.
 
-When the system restarts, the reason for the restart is contained in the system registers at boot time in a platform specific manner. This API provides a generic method of fetching the reason for the restart.
+You can use the ResetReason interface to determine the cause of the last system reset in a portable fashion.
 
 ### ResetReason class reference
 
@@ -10,7 +10,7 @@ When the system restarts, the reason for the restart is contained in the system 
 
 ### ResetReason example
 
-Check the cause of the last system reset.
+Check the cause of the last system reset:
 
 ```c++
 #include "mbed.h"

--- a/docs/api/drivers/ResetReason.md
+++ b/docs/api/drivers/ResetReason.md
@@ -1,0 +1,39 @@
+## ResetReason
+
+Use the ResetReason interface to access hardware reset reason registers in a portable fashion.
+
+### ResetReason class reference
+
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.8/mbed-os-api-doxy/classmbed_1_1_resetreason.html)
+
+### ResetReason example
+
+```c++
+#include "mbed.h"
+#include "ResetReason.h"
+
+#include <string>
+
+std::string reset_reason_to_string(const reset_reason_t reason)
+{
+  switch (reason)
+  {
+  case RESET_REASON_POWER_ON:
+    return "Power On";
+  case RESET_REASON_PIN_RESET:
+    return "Hardware Pin";
+  case RESET_REASON_SOFTWARE:
+    return "Software Reset";
+  case RESET_REASON_WATCHDOG:
+    return "Watchdog";
+  default:
+    return "Other Reason";
+  }
+}
+
+int main() {
+  const reset_reason_t reason = ResetReason::get();
+
+  printf("Last system reset reason: %s\n", reset_reason_to_string(reason).c_str());
+}
+```

--- a/docs/api/drivers/ResetReason.md
+++ b/docs/api/drivers/ResetReason.md
@@ -16,24 +16,24 @@ Use the ResetReason interface to access hardware reset reason registers in a por
 
 std::string reset_reason_to_string(const reset_reason_t reason)
 {
-  switch (reason)
-  {
-  case RESET_REASON_POWER_ON:
-    return "Power On";
-  case RESET_REASON_PIN_RESET:
-    return "Hardware Pin";
-  case RESET_REASON_SOFTWARE:
-    return "Software Reset";
-  case RESET_REASON_WATCHDOG:
-    return "Watchdog";
-  default:
-    return "Other Reason";
-  }
+    switch (reason) {
+        case RESET_REASON_POWER_ON:
+            return "Power On";
+        case RESET_REASON_PIN_RESET:
+            return "Hardware Pin";
+        case RESET_REASON_SOFTWARE:
+            return "Software Reset";
+        case RESET_REASON_WATCHDOG:
+            return "Watchdog";
+        default:
+            return "Other Reason";
+    }
 }
 
-int main() {
-  const reset_reason_t reason = ResetReason::get();
+int main()
+{
+    const reset_reason_t reason = ResetReason::get();
 
-  printf("Last system reset reason: %s\n", reset_reason_to_string(reason).c_str());
+    printf("Last system reset reason: %s\r\n", reset_reason_to_string(reason).c_str());
 }
 ```

--- a/docs/api/drivers/Watchdog.md
+++ b/docs/api/drivers/Watchdog.md
@@ -1,6 +1,6 @@
 # Watchdog
 
-Use the Watchdog interface to set up a hardware watchdog. If you fail to refresh the watchdog periodically, it will reset the system after a set period of time.
+Use the Watchdog interface to set up a hardware watchdog timer that will reset the system in the case of system failures or malfunctions. If you fail to refresh the watchdog periodically, it will reset the system after a set period of time.
 
 <span class="notes">**Note:** There is only one instance in the system. Use `Watchdog::get_instance()` to obtain a reference. </span>
 

--- a/docs/api/drivers/Watchdog.md
+++ b/docs/api/drivers/Watchdog.md
@@ -1,10 +1,12 @@
 # Watchdog
 
-Use the Watchdog interface to set up a hardware watchdog timer that will reset the system in the case of system failures or malfunctions. If you fail to refresh the watchdog periodically, it will reset the system after a set period of time.
+You can use the Watchdog interface to set up a hardware watchdog timer that resets the system in the case of system failures or malfunctions. 
 
 <span class="notes">**Note:** There is only one instance in the system. Use `Watchdog::get_instance()` to obtain a reference. </span>
 
-<span class="notes">**Note:** The maximum amount of time that you can set as the Watchdog timeout varies depending on the target hardware. You can check the maximum value by calling `Watchdog::get_instance().get_max_timeout()`.</span>
+If you fail to refresh the watchdog periodically, it resets the system after a set period of time.
+
+<span class="notes">**Note:** The maximum amount of time you can set as the Watchdog timeout varies depending on the target hardware. You can check the maximum value by calling `Watchdog::get_instance().get_max_timeout()`.</span>
 
 ### Watchdog class reference
 
@@ -12,7 +14,7 @@ Use the Watchdog interface to set up a hardware watchdog timer that will reset t
 
 ### Watchdog example
 
-Create a watchdog timer that expires after 5 seconds and that you refresh by pushing BUTTON1 on the target board.
+This example creates a watchdog timer that expires after five seconds and that you can refresh by pushing BUTTON1 on the target board:
 
 ```c++
 #include "mbed.h"

--- a/docs/api/drivers/Watchdog.md
+++ b/docs/api/drivers/Watchdog.md
@@ -10,7 +10,7 @@ If you fail to refresh the watchdog periodically, it resets the system after a s
 
 ### Watchdog class reference
 
-[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.8/mbed-os-api-doxy/classmbed_1_1_watchdog.html)
+[![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_watchdog.html)
 
 ### Watchdog example
 

--- a/docs/api/drivers/Watchdog.md
+++ b/docs/api/drivers/Watchdog.md
@@ -1,11 +1,49 @@
 # Watchdog
 
-[Add description here.]
+Use the Watchdog interface to set up a hardware watchdog. If you fail to refresh the watchdog periodically, it will reset the system after a set period of time.
 
-## Watchdog class reference
+<span class="notes">**Note:** There is only one instance in the system. Use `Watchdog::get_instance()` to obtain a reference. </span>
 
-[Add class reference here. Ask your editor for help if you've never done this before.]
+<span class="notes">**Note:** The maximum amount of time that you can set as the Watchdog timeout varies depending on the target hardware. You can check the maximum value by calling `Watchdog::get_instance().get_max_timeout()`.</span>
 
-## Watchdog example
+### Watchdog class reference
 
-[Add example here.]
+[![View code](https://www.mbed.com/embed/?type=library)](http://os-doc-builder.test.mbed.com/docs/v5.8/mbed-os-api-doxy/classmbed_1_1_watchdog.html)
+
+### Watchdog example
+
+Create a watchdog timer that expires after 5 seconds and that you refresh by pushing BUTTON1 on the target board.
+
+```c++
+#include "mbed.h"
+
+const uint32_t TIMEOUT_MS = 5000;
+InterruptIn button(BUTTON1);
+volatile int countdown = 9;
+
+void trigger()
+{
+    Watchdog::get_instance().kick();
+    countdown = 9;
+}
+
+int main()
+{
+    printf("\r\nTarget started.\r\n");
+
+    Watchdog &watchdog = Watchdog::get_instance();
+    watchdog.start(TIMEOUT_MS);
+    button.rise(&trigger);
+
+    uint32_t watchdog_timeout = watchdog.get_timeout();
+    printf("Watchdog initialized to %lu ms.\r\n", watchdog_timeout);
+    printf("Press BUTTON1 at least once every %lu ms to kick the "
+           "watchdog and prevent system reset.\r\n", watchdog_timeout);
+
+    while (1) {
+        printf("\r%3i", countdown--);
+        fflush(stdout);
+        wait(TIMEOUT_MS / 1000.0 / 10);
+    }
+}
+```


### PR DESCRIPTION
Add docs for the new drivers introduced in https://github.com/ARMmbed/mbed-os/pull/10857.

This is mostly based on #404 (I wasn't able to cherry-pick these commits though). The `ResetReason.md` is unchanged. `Watchdog.md` is updated.

TODO:
- [x] update `ResetReason` class reference link,
- [x] update `Watchdog` class reference link.