### PR TITLE
Removed -doxy from docs list and store artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,9 @@ jobs:
           command: |
             source /tmp/env
             cd /tmp/workspace/artifacts/$CIRCLE_BRANCH_NO_SLASH
-            find -maxdepth 2 -type f -name '*.html' -printf '%P\n'
+            find -maxdepth 2 -type f -name '*.html' -not -path "*-doxy/*" -printf '%P\n' > /tmp/workspace/page_list.txt
+      - store_artifacts:
+          path: /tmp/workspace/page_list.txt
 
   make_live:
     executor: doc_builder


### PR DESCRIPTION
This change filters all doxy pages from the page list, and also stores it in the artifacts.

You can see an example of this in the artifacts for this job https://circleci.com/gh/ARMmbed/mbed-os-5-docs/6546#artifacts/containers/0