### PR TITLE
Bump version of latest live version in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,6 @@ If you want to contribute, please read our [contribution guide](https://os.mbed.
 Please open pull requests against either:
 
 - `development` - this is our development branch.
-- `5.12` - this is the latest live version.
+- `5.13` - this is the latest live version.
 
 Older version branches probably don't require fixes; please open an issue if you think we're wrong.


### PR DESCRIPTION
Fix the latest live version in the `readme.md` file, as I believe this was a mistake