### PR TITLE
Create detailed custom-target-porting.md

### DIFF
--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -152,7 +152,7 @@ You may be wondering why there are more directory levels than target configurati
       
 1. Modify the files.
 
-   `PinNames.h` is the most common file to be edited. For our example, the ImaginaryBoard is using I2C but connected to different supported signals. Change the I2C pin macro definitions from:
+   `PinNames.h` is the most common file to be edited. For our example, the ImaginaryBoard uses I2C connected to different supported signals. Change the I2C pin macro definitions from:
    
    ```
    I2C_SCL     = D15,

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -4,7 +4,7 @@ When designing a custom board based on an existing Mbed Enabled board, you may n
 
 Mbed OS supports target inheritance, which allows you to extend an existing microcontroller (MCU) target and just add software and configurations required for your board. You have the ability to add a file named `custom_target.json` to your project, which can store your custom target configurations without the need to modify `targets.json`.
 
-This tutorial provides a quick overview on how to create a custom port using `custom_target.json`. It covers the most common methods. For detailed information covering all the ways you can configure targets, go to [adding and configuring targets](../reference/adding-and-configuring-targets.html).
+This tutorial covers the most common methods used to create a custom port with `custom_target.json`. For detailed information covering all the ways you can configure targets, go to [adding and configuring targets](../reference/adding-and-configuring-targets.html).
 
 ## Extending an existing MCU target configuration
 

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -224,7 +224,7 @@ You may be wondering why there are more directory levels than target configurati
 
 1. Program the board.  
 
-  You can test this simple example using a `DISCO-L475VG-IOT01A`. If you actually created a `ImaginaryBoard` board, you could use that too.  
+  You can test this simple example using a `DISCO-L475VG-IOT01A`. If you actually created an `ImaginaryBoard` board, you could use that too.  
   
   <span class="notes">**Note:** Unless your board has an Mbed Enabled debug interface, you need a method of flashing the memory on your board. </span>
   

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -89,7 +89,7 @@ Assuming you have Mbed CLI installed, follow these steps to make the port.
 
    - The `macros_add` section was changed to remove `USBHOST_OTHER` because USB is not used on the new board.
 
-   - The `device_has_add` section was changed to not add the `ANALOGOUT`, `CAN`, `USBDEVICE` drivers because those features are not used on the new board.
+   - The `device_has_add` section was changed to not add the `ANALOGOUT`, `CAN`, and `USBDEVICE` drivers because those features are not used on the new board.
 
    - A new section, `device_has_remove`, was added. This removes `ANALOGIN`, `I2CSLAVE`, and `I2C_ASYNCH` drivers because these features are also not used.  The reason why `device_has_remove` is used in this case is because the board is inheriting from the MCU Family configuration `FAMILY_STM32`, which has those drivers added by default.
 

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -101,7 +101,7 @@ Assuming you have Mbed CLI installed, follow these steps to make the port.
 
    <span class="notes">**Note:** If you choose to add a driver that is not already available for your hardware, you will have to provide the driver implementation.</span>
 
-   - (Optional) Similarly, you can use `features_add`, `features_remove`, `components_add`, `components_remove`, `macros_add` and `macros_remove` to add/remove configurations.
+   - (Optional) Similarly, you can use `features_add`, `features_remove`, `components_add`, `components_remove`, `macros_add` and `macros_remove` to add or remove configurations.
 
 ## Configuring the target code directories
 

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -1,28 +1,28 @@
 # Using Mbed OS on a custom board
 
-When designing a custom microcontroller board to run Mbed OS, you may need to make software customizations for the unique design choices you have made for your new board, such as clocking, pin connections, and peripheral usage. This can be accomplished by adding configuration and source files to an Mbed OS-based application project without the need to modify files within Mbed Os itself. If you are using Mbed OS version 5.8 and later, you can add a file named `custom_targets.json` to your project, which can store your custom target configurations. If your board is based on an existing Mbed Enabled microcontroller, you can simply extend that board configuration without the need to implement all the files yourself.
+When designing a custom microcontroller board to run Mbed OS, you may need to make software customizations for the unique design choices you have made for your new board, such as clocking, pin connections and peripheral use. You can accomplish this by adding configuration and source files to an Mbed OS-based application project without the need to modify files within Mbed OS, itself. You can add a file named `custom_targets.json` to your project, which can store your custom target configurations. If your board is based on an existing Mbed Enabled microcontroller, you can simply extend that board configuration without the need to implement all the files yourself.
 
 This tutorial covers the most common methods used to create a custom port of Mbed OS when starting from an existing Mbed Enabled board. For detailed information on how to create a port from scratch, go to the [Mbed Porting guide](../porting/index.html). Additionally, not all possible aspects of target configuration are covered. For detailed information on all the ways you can configure targets, go to [adding and configuring targets](../reference/adding-and-configuring-targets.html).
 
 ## Extending an existing MCU target configuration
 
-Consider a situation in which you are creating a new board based on an existing Mbed Enabled board. For this tutorial, we will list the steps to create the software for a new board we will call `ImaginaryBoard`. This board will be based on [DISCO-L475VG-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/). It will share most of the features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN`, or `USB`. Some pins are connected differently on the new board. 
+Consider a situation in which you are creating a new board based on an existing Mbed Enabled board. This tutorial lists the steps to create the software for a new board we will call `ImaginaryBoard`. This board is based on [DISCO-L475VG-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/). It shares most of the features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN` or `USB`. Some pins are connected differently on the new board. 
 
 Follow these steps to create a custom port for Mbed OS:
 
-### Get everything ready
+### Preparing
 
 1. [Install Mbed CLI](../tools/installation-and-setup.html) if you don't already have it.
 
 1. (Optional) Create a new Mbed program (for example, `mbed-os-imaginary-port`).
 
-   If you don't already have an Mbed program on your computer, at a command terminal, run this Mbed CLI command:
+   If you don't already have an Mbed program on your computer, run this Mbed CLI command in a command terminal:
 
    ```
    mbed new --program mbed-os-imaginary-port
-
    ```
-   This command will create a new program folder called `mbed-os-imaginary-port` and then import `mbed-os` from the [official Mbed OS source repository](https://github.com/armmbed/mbed-os) into it.
+   
+   This command creates a new program folder called `mbed-os-imaginary-port` and then imports `mbed-os` from the [official Mbed OS source repository](https://github.com/armmbed/mbed-os) into it.
 
 1. Change directories into your new project:
 
@@ -30,15 +30,15 @@ Follow these steps to create a custom port for Mbed OS:
   cd mbed-os-imaginary-port
   ```
 
-1. Create a new file named `custom_targets.json` at the same level as the `mbed-os` directory:
+1. Create a new file named `custom_targets.json` at the same level as the `mbed-os` directory.
 
 1. Inspect the contents of `mbed-os/targets/targets.json`. For this example, search for `DISCO_L475VG_IOT01A`.
 
 1. Copy the contents from the `DISCO_L475VG_IOT01A` section into your `custom_targets.json` file. Be sure to include brackets `{ }` surrounding the content.
 
-### Start customizing
+### Customizing
 
-1. Now make changes to `custom_targets.json` for your board. For example, after making changes, the full contents look like this:
+1. Make changes to `custom_targets.json` for your board. For example, after making changes, the full contents look like this:
    
    ```
    {
@@ -85,42 +85,35 @@ Follow these steps to create a custom port for Mbed OS:
 
    Let's review the changes one by one.
 
-#### Things changed
+#### Changes
 
-   - The board name was changed from `DISCO_L475VG_IOT01A` to `IMAGINARYBOARD` so the board can be uniquely identified.
+1. The board name changed from `DISCO_L475VG_IOT01A` to `IMAGINARYBOARD`, so the board can be uniquely identified.
+1. The `detect_code` changed from `0764` to `1234`. The `detect_code` is a unique number that identifies the board to the Mbed OS test tools. For Mbed Enabled boards, this number is exposed through the debug interface with Mbed CLI by typing `mbedls`.
+1. The `macros_add` section changed to remove `USBHOST_OTHER` because the new board does not use USB.
+1. The `device_has_add` section was changed to remove the `ANALOGOUT`, `CAN`, and `USBDEVICE` drivers because the new board doesn't use those features.
 
-   - The `detect_code` was changed from `0764` to `1234`. The `detect_code` is a unique number that identifies the board to the Mbed OS test tools. For Mbed Enabled boards, this number is exposed through the debug interface with Mbed CLI by typing `mbedls`.
+#### Additions
 
-   - The `macros_add` section was changed to remove `USBHOST_OTHER` because USB is not used on the new board.
+A new section, `device_has_remove`, was added. This removes the `ANALOGIN`, `I2CSLAVE` and `I2C_ASYNCH` drivers because these features are also not used. The reason why `device_has_remove` is used in this case is because the board is inheriting from the MCU Family configuration `FAMILY_STM32`, which has those drivers added by default.
 
-   - The `device_has_add` section was changed to not add the `ANALOGOUT`, `CAN`, and `USBDEVICE` drivers because those features are not used on the new board.
+#### Other possible additions 
 
-#### Things added
+Other changes you may need include:
 
-    - A new section, `device_has_remove`, was added. This removes the `ANALOGIN`, `I2CSLAVE`, and `I2C_ASYNCH` drivers because these features are also not used. The reason why `device_has_remove` is used in this case is because the board is inheriting from the MCU Family configuration `FAMILY_STM32`, which has those drivers added by default.
+   - `features_add`, `features_remove`, `components_add`, `components_remove`, `macros_add` and `macros_remove` to add or remove configurations.
+   - `device_has_add` to add additional drivers.
 
-
-#### Other things you may need to add 
-
-    Here are some other changes that might also be needed.
-   
-    - You can also use `device_has_add` to add additional drivers.
-
-    <span class="notes">**Note:** If you choose to add a driver that is not already available for your hardware, you will have to provide the driver implementation.</span>
-
-    - You can use `features_add`, `features_remove`, `components_add`, `components_remove`, `macros_add` and `macros_remove` to add or remove configurations.
-
+   <span class="notes">**Note:** If you choose to add a driver that is not already available for your hardware, you will have to provide the driver implementation.</span>
 
 #### Where other configurations live 
 
-    All the other configurations for the board are inherited from the MCU Family configuration called `FAMILY_STM32`.
-
+All the other configurations for the board are inherited from the MCU Family configuration called `FAMILY_STM32`.
 
 ## Configuring the target code directories
 
-   In some cases, the target source code directories follow a similar structure as the target configuration, but they could have a few more levels.
+In some cases, the target source code directories follow a similar structure to the target configuration, but they could have a few more levels.
 
-   For example, in the `mbed-os/targets` folder, the target directories for DISCO_L475VG_IOT01A follow this pattern:
+For example, in the `mbed-os/targets` folder, the target directories for DISCO_L475VG_IOT01A follow this pattern:
 
    ```
    mbed-os
@@ -131,33 +124,32 @@ Follow these steps to create a custom port for Mbed OS:
              |                    |_TARGET_DISCO_L475VG_IOT01A     <- Board
    ```
 
-    Boards typically inherit files that support the MCU, MCU family, and MCU vendor. When adding a new board, you need to add a new set of files for the board.
+Boards typically inherit files that support the MCU, MCU family and MCU vendor. When adding a new board, you need to add a new set of files for the board.
 
-    You may be wondering why there are more directory levels than target configuration levels. This is because many targets utilize the `extra_labels_add` feature in the target configuration. The keywords `STM32L4`, `STM32L475xG`, `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG`, `TARGET_STM32L475VG` respectively. With those labels applied, these directory names get included in the build for this target.
+There are more directory levels than target configuration levels because many targets use the `extra_labels_add` feature in the target configuration. The keywords `STM32L4`, `STM32L475xG` and `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG` and `TARGET_STM32L475VG`, respectively. With those labels applied, the build includes these directory names for this target.
 
-
-### Get everything ready
+### Preparing
 
 1. Create a new directory called `TARGET_IMAGINARYBOARD` at the top level of your project to store the source files for your board.
       
-    Inspect the files at `mbed-os\targets\TARGET_STM\TARGET_STM32L4\TARGET_STM32L475xG\TARGET_DISCO_L475VG_IOT01A`. You should find the following files or similar:  
+1. Inspect the files at `mbed-os\targets\TARGET_STM\TARGET_STM32L4\TARGET_STM32L475xG\TARGET_DISCO_L475VG_IOT01A`. You should find the following files or similar:
    
-    `PeripheralNames.h`, `PeripheralPins.c`, `PinNames.h`, `system_clock.c`
+   `PeripheralNames.h`, `PeripheralPins.c`, `PinNames.h`, `system_clock.c`
    
-    Copy the files into your new `TARGET_IMAGINARYBOARD` directory.
+1. Copy the files into your new `TARGET_IMAGINARYBOARD` directory.
    
-    The files provide these capabilities.
+   The files provide these capabilities:
       
-    - `PeripheralNames.h` describes the available peripherals and their base addresses.
-    - `PeripheralPins.c` describes the available pins and their association with peripherals.
-    - `PinNames.h` sets macros for pins that define their function.
-    - `system_clock.c` vendor specific file that initializes the system and sets up the clocks.
+   - `PeripheralNames.h` describes the available peripherals and their base addresses.
+   - `PeripheralPins.c` describes the available pins and their association with peripherals.
+   - `PinNames.h` sets macros for pins that define their function.
+   - `system_clock.c` vendor specific file that initializes the system and sets up the clocks.
 
-### Start customizing
+### Customizing
       
 1. Modify the files.
 
-   `PinNames.h` is the most common file to be edited. For our example, the ImaginaryBoard uses I2C but connected to different supported signals. Change the I2C pin macro definitions from:
+   `PinNames.h` is the most common file to be edited. For this tutorial, the ImaginaryBoard uses I2C but connected to different supported signals. Change the I2C pin macro definitions from:
    
    ```
    I2C_SCL     = D15,
@@ -171,47 +163,45 @@ Follow these steps to create a custom port for Mbed OS:
    I2C_SDA     = PC_1,
    ```
    
-    You may also choose to add or remove peripherals, add or remove pins, or change the clock frequency by editing `PeripheralNames.h`, `PeripheralPins.c`, or `system_clock.c`. In our example, for simplicity, we will not edit these files. 
+   You may also choose to add or remove peripherals, add or remove pins or change the clock frequency by editing `PeripheralNames.h`, `PeripheralPins.c`, or `system_clock.c`. For simplicity, this tutorial doesn't edit these files.
    
-1. (Optional) Add additional files.
-
-   If necessary, add additional source files for drivers or middleware you have implemented for the new board. In our example, we do not have any files to add.
+1. (Optional) Add additional source files for drivers or middleware you have implemented for the new board. This tutorial doesn't have any files to add.
 
 1. (Optional) Add a simple application source file for testing.
 
-    To confirm the software builds for the new target, add a file named `main.cpp` with the following contents:
+   To confirm the software builds for the new target, add a file named `main.cpp` with the following contents:
 
-    ```  
-    #include "mbed.h"
-    
-    DigitalOut led1(LED1);
+   ```  
+   #include "mbed.h"
+   
+   DigitalOut led1(LED1);
 
-    int main()
-    {
-        while (true) {
-            led1 = !led1;
-            wait_ms(500);
-        }
-    }
-    ``` 
-    
-    This blinks an led. If `LED1` is not defined, inspect `PinNames.h` for a valid pin definition for an available led.
+   int main()
+   {
+       while (true) {
+           led1 = !led1;
+           wait_ms(500);
+       }
+   }
+   ``` 
+   
+   This blinks an LED. If `LED1` is not defined, inspect `PinNames.h` for a valid pin definition for an available LED.
        
-    Your directory should now look something like this:
+   Your directory now looks something like this:
     
-    ```
-    main.cpp
-    custom_target.json
-    TARGET_IMAGINARYBOARD
-    mbed-os
-    .mbed
-    mbed_settings.py
-    mbed-os.lib
-    ```
+   ```
+   main.cpp
+   custom_target.json
+   TARGET_IMAGINARYBOARD
+   mbed-os
+   .mbed
+   mbed_settings.py
+   mbed-os.lib
+   ```
 
-## Test your code 
+## Testing your code 
     
-1. Compile the application.
+1. Compile the application:
    
    ```
    mbed compile -m IMAGINARYBOARD -t <toolchain>
@@ -227,43 +217,42 @@ Follow these steps to create a custom port for Mbed OS:
 
 1. Program the board.
 
-  You can test this simple example using a `DISCO-L475VG-IOT01A`. If you actually created a `ImaginaryBoard` board, you could use that too.
+   You can test this using a `DISCO-L475VG-IOT01A`. If you actually created an `ImaginaryBoard` board, you could use that, too.
   
-  <span class="notes">**Note:** Unless your board has an Mbed Enabled debug interface, you need a method of flashing the memory on your board. </span>
+   <span class="notes">**Note:** Unless your board has an Mbed Enabled debug interface, you need a method of flashing the memory on your board.</span>
   
-  Since the `DISCO-L475VG-IOT01A` has a Mbed Enabled debug interface (STLink in this case), we can use drag-and-drop programming to flash the board.
+   Because the `DISCO-L475VG-IOT01A` has an Mbed Enabled debug interface (STLink in this case), you can use drag-and-drop programming to flash the board.
   
-  Locate the binary file and drag it onto the disk drive name for the board (for example, `DIS_L4IOT`).
+1. Locate the binary file, and drag it onto the disk drive name for the board (for example, `DIS_L4IOT`).
   
-  Wait for the file transfer to complete.
-  
+1. Wait for the file transfer to complete.
+   
 1. Run the application
 
-  Press the reset button on the board. You should see the led blinking.
+   Press the reset button on the board. You should see the LED blinking.
  
 1. (Optional) Run automated tests.
 
-  With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port. Since a new board has a new name that is unknown to the Mbed tools, you will need to tell the tools which `detect_code` to associate it to.
+   With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port. Because a new board has a new name unknown to the Mbed tools, you need to tell the tools which `detect_code` to associate it to.
+   
+   To do this, you can use the `mbedls` `mock` command option. This tutorial tests with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its detect code. If you have a new board that uses a different `detect_code`, such as `1234`, then use that.
   
-  To do this, you can use the `mbedls` `mock` command option. In our case, we are testing with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its detect code. If you have a new board that is using a different detect_code, such as `1234`, then use that.
-  
-  For the `ImaginaryBoard` based on `DISCO-L475VG-IOT01A`, run this command.
+   For the `ImaginaryBoard` based on `DISCO-L475VG-IOT01A`, run this command.
 
-  ```
-  mbedls --mock 0764:IMAGINARYBOARD
-  ```
+   ```
+   mbedls --mock 0764:IMAGINARYBOARD
+   ```
    
    <span class="notes">**Note:** Contact the Arm Mbed team to get a unique ID if you plan to have your board coexist with other Mbed Enabled boards while running automated tests.</span>
 
-  Now run the tests, with the following command.
-  
-  ```
-  mbed test -m IMAGINARYBOARD -t <toolchain>
-  ```
-  
-  The tests should start running.
-  
-  For more information on testing a new board, go to the [Testing your port](../porting/testing.html) section of the porting guide.
-  
-### Success! 
+1. Run the tests, with the following command:
+   
+   ```
+   mbed test -m IMAGINARYBOARD -t <toolchain>
+   ```
+   
+   The tests start running.
+   
+   For more information on testing a new board, go to the [Testing your port](../porting/testing.html) section of the porting guide.
+
 Now you have successfully ported Mbed OS to a new board.

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -99,7 +99,7 @@ Assuming you have Mbed CLI installed, follow these steps to make the port.
    
    - (Optional) You can also use `device_has_add` to add additional drivers.
 
-   <span class="notes">**Note:** If you choose to add a driver, you may have to provide the driver implementation if it is not already available for your hardware.</span>
+   <span class="notes">**Note:** If you choose to add a driver that is not already available for your hardware, you will have to provide the driver implementation.</span>
 
    - (Optional) Similarly, you can use `features_add`, `features_remove`, `components_add`, `components_remove`, `macros_add` and `macros_remove` to add/remove configurations.
 

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -88,7 +88,7 @@ Follow these steps to create a custom port for Mbed OS:
 #### Changes
 
 1. The board name changed from `DISCO_L475VG_IOT01A` to `IMAGINARYBOARD`, so the board can be uniquely identified.
-1. The `detect_code` changed from `0764` to `1234`. The `detect_code` is a unique number that identifies the board to the Mbed OS test tools. For Mbed Enabled boards, this number is exposed through the debug interface with Mbed CLI by typing `mbedls`.
+1. The `detect_code` changed from `0764` to `1234`. The `detect_code` is a unique four-digit hexadecimal value, also called a `Platform ID`, that identifies the board to the Mbed OS test tools. For Mbed Enabled boards, this number is exposed through the debug interface with Mbed CLI by typing `mbedls`.
 1. The `macros_add` section changed to remove `USBHOST_OTHER` because the new board does not use USB.
 1. The `device_has_add` section was changed to remove the `ANALOGOUT`, `CAN`, and `USBDEVICE` drivers because the new board doesn't use those features.
 
@@ -233,9 +233,9 @@ There are more directory levels than target configuration levels because many ta
  
 1. (Optional) Run automated tests.
 
-   With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port. Because a new board has a new name unknown to the Mbed tools, you need to tell the tools which `detect_code` to associate it to.
+   With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port. Because a new board has a new name unknown to the Mbed tools, you need to tell the tools which `Platform ID` (aka `detect_code`) to associate it to.
    
-   To do this, you can use the `mbedls` `mock` command option. This tutorial tests with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its detect code. If you have a new board that uses a different `detect_code`, such as `1234`, then use that.
+   To do this, you can use the `mbedls` `mock` command option. This tutorial tests with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its `Platform ID`. If you have a new board that uses a different `Platform ID`, such as `1234`, then use that.
   
    For the `ImaginaryBoard` based on `DISCO-L475VG-IOT01A`, run this command.
 
@@ -243,7 +243,7 @@ There are more directory levels than target configuration levels because many ta
    mbedls --mock 0764:IMAGINARYBOARD
    ```
    
-   <span class="notes">**Note:** Contact the Arm Mbed team to get a unique ID if you plan to have your board coexist with other Mbed Enabled boards while running automated tests.</span>
+  <span class="notes">**Note:** If you intend to release a new target to the Mbed community, it needs a unique Platform ID. To get one, please contact your technical account manager or email [our support team](mailto:support@mbed.com).</span>
 
 1. Run the tests, with the following command:
    

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -10,7 +10,7 @@ This tutorial covers the most common methods used to create a custom port with `
 
 As an example, consider a situation in which you are creating a new board based on an existing Mbed Enabled board. For this tutorial, consider a new board called `ImaginaryBoard` that is based on [DISCO-L475VG-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/).
 
-`ImaginaryBoard` shares most of the same features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN` or `USB`. Some pins are also connected differently on the new board.
+`ImaginaryBoard` shares most of the features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN` or `USB`. Some pins are also connected differently on the new board.
 
 Assuming you have Mbed CLI installed, follow these steps to make the port.
 

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -1,0 +1,258 @@
+# Porting Mbed OS to a custom board
+
+When designing a custom board based on an existing Mbed Enabled board, you will likely need to make configuration and software changes to adapt Mbed OS to run on your new board.  This is often called a software 'port'.  The necessary changes may include adaptations for the unique design choices you have made for your new board, such as clocking, pin connections, and peripheral usage.  This can often be accomplished by adding configuration and source files to an Mbed OS-based application project without the need to modify files within Mbed Os itself.  If you don't plan to push your changes to the upstream Mbed Os repository, this simplifies your software configuration management by allowing you to keep your new files separate.  
+
+Mbed OS supports target inheritance, which allows you to extend an existing microcontroller (MCU) target and just add additional software and configurations required for your board.  If you are using Mbed OS version 5.8 and later, you have the ability to add a file named `custom_target.json` to your project, which can store your custom target configurations without the need to modify `targets.json`.
+
+This tutorial provides a quick overview on how to create a custom port using `custom_target.json`.  Not all possible aspects of this process are covered.  For detailed information covering all the ways you can configure targets, go to [adding and configuring targets](../reference/adding-and-configuring-targets.html).
+
+## Extending an existing MCU target configuration
+
+As an example, consider a situation in which you are creating a new board based on an existing Mbed Enabled board.  For this tutorial, consider a new board called `ImaginaryBoard` that is based on [DISCO-L475VG-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/).
+
+`ImaginaryBoard` shares most of the same features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN`, `USB` and some pins are connected differently on the new board.   
+
+Assuming you have Mbed Command Line Interface (CLI) installed, follow these steps to make the port.
+
+1. (Optional) Create a new Mbed program (e.g. mbed-os-imaginary-port)
+
+  If you don't already have an Mbed program on your computer, at a command terminal, run this Mbed CLI command.
+
+  ```
+  mbed new --program mbed-os-imaginary-port
+
+  ```
+  This command will import 'mbed-os' from the [official Mbed OS source repository](https://github.com/armmbed/mbed-os) into a new directory called 'mbed-os-imaginary-port'.
+
+  Now change directories into your new project.  
+
+  ```
+  cd mbed-os-imaginary-port
+  ```
+
+1. Create a new file named `custom_targets.json` at the same level as the `mbed-os` directory.
+
+  Inspect the contents of `mbed-os/targets/targets.json`.  For this example, search for `DISCO_L475VG_IOT01A`.  
+
+  Copy the contents from the `DISCO_L475VG_IOT01A` section into your `custom_targets.json` file.  Be sure to include brackets `{ }` sorrounding the content.
+
+  Then make changes for your board.  For example, after making changes, the full contents look like this:
+   
+   ```
+   {
+     "IMAGINARYBOARD": {
+         "components_add": ["QSPIF", "FLASHIAP"],
+         "inherits": ["FAMILY_STM32"],
+         "core": "Cortex-M4F",
+         "extra_labels_add": ["STM32L4", "STM32L475xG", "STM32L475VG"],
+         "config": {
+             "clock_source": {
+                 "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                 "value": "USE_PLL_MSI",
+                 "macro_name": "CLOCK_SOURCE"
+             },
+             "lpticker_lptim": {
+                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                 "value": 1
+             }
+         },
+         "overrides": { "lpticker_delay_ticks": 4 },
+         "detect_code": ["1234"],
+         "macros_add": [
+             "MBED_TICKLESS",
+             "MBED_SPLIT_HEAP"
+         ],
+         "device_has_add": [
+             "CRC",
+             "TRNG",
+             "FLASH",
+             "QSPI",
+             "MPU"
+         ],
+         "device_has_remove": [         
+             "ANALOGIN",
+             "I2CSLAVE",
+             "I2C_ASYNCH"
+         ],                     
+         "release_versions": ["2", "5"],
+         "device_name": "STM32L475VG",
+         "bootloader_supported": true
+     }
+   }
+   ```
+
+   Let's review the changes one by one.
+
+   - The board name was changed from `DISCO_L475VG_IOT01A` to `IMAGINARYBOARD` so the board can be uniquely identified.
+
+   - The `detect_code` was changed from `0764` to `1234`.  The `detect_code` is a unique number that identifies the board to the Mbed OS test tools.  This number is typically built into the debug interface.  
+
+   - The `macros_add` section was changed to remove `USBHOST_OTHER` because USB is not used on the new board.
+
+   - The `device_has_add` section was changed to not add the  `ANALOGOUT`, `CAN`, `USBDEVICE` drivers because those features are not used on the new board.
+
+   - A new section, `device_has_remove`, was added.  This removes `ANALOGIN`, `I2CSLAVE`, and `I2C_ASYNCH` drivers because these features are also not used.  The reason why `device_has_remove` is used in this case is because the board is inheriting from the MCU Family configuration `FAMILY_STM32`, which has those drivers added by default.
+
+   All the other configurations for the board are inherited from the MCU Family configuration called `FAMILY_STM32`.  
+
+   Here are some other typical changes that might be needed.
+   
+   - (Optional) You can also use `device_has_add` to add additional drivers.
+
+   <span class="notes">**Note:** If you choose to add a driver, you may have to provide the driver implementation if it is not already available for your hardware.</span>
+
+   - (Optional) Similarly, you can use `features_add`, `features_remove`, `components_add`, `components_remove`, `macros_add` and `macros_remove` to add/remove configurations.
+
+## Configuring the target code directories
+
+  In some cases, the target source code directories follow a similar structure as the target configuration, but they could have a few more levels.  
+
+  For example, in the `mbed-os/targets` folder, the target directories for DISCO_L475VG_IOT01A follow this pattern:
+
+  ```
+  mbed-os
+      |_targets
+            |_TARGET_STM            <- MCU VENDOR
+            |      |_TARGET_STM32L4             <- MCU FAMILY
+            |             |_TARGET_STM32L475xG               <- MCU
+            |                    |_TARGET_DISCO_L475VG_IOT01A     <- Board
+  ```
+
+  Boards typically inherit files that support the MCU, MCU family, and MCU vendor.  When adding a new board, you need to add a new set of files for the board.
+
+  You may be wondering why there are more directory levels than target configuration levels.  This is because many targets utilize the `extra_labels_add` feature in the target configuration.  The following keywords `STM32L4`, `STM32L475xG`, `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG`, `TARGET_STM32L475VG` respectively.  With those labels applied, these directory names get included in the build for this target.  
+
+1. Create a new directory called `TARGET_IMAGINARYBOARD` at the top level of your project.
+   
+   Your directory should look something like this:
+   
+   ```
+   custom_target.json
+   TARGET_IMAGINARYBOARD
+   mbed-os
+   .mbed
+   mbed_settings.py
+   mbed-os.lib
+   ```
+   
+1. Now place source files for the board.
+   
+   Inspect the files at `mbed-os\targets\TARGET_STM\TARGET_STM32L4\TARGET_STM32L475xG\TARGET_DISCO_L475VG_IOT01A`.  You should find the following files or similar.  
+   
+   `PeripheralNames.h`, `PeripheralPins.c`, `PinNames.h`, `system_clock.c`
+   
+   Copy the files into your new `TARGET_IMAGINARYBOARD` directory.
+   
+   The files provide these capabilities.
+      
+   - `PeripheralNames.h` describes the available peripherals and their base addresses
+   - `PeripheralPins.c` describes the available pins and their association with peripherals 
+   - `PinNames.h` sets macros for pins that define their function.
+   - `system_clock.c` vendor specific file that initializes the system and sets up the clocks
+      
+1. Modify the files.
+
+   `PinNames.h` is the most common file to be edited.  For our example, the ImaginaryBoard is using I2C but connected to different supported signals.  Change the I2C pin macro definitions from:
+   
+   ```
+   I2C_SCL     = D15,
+   I2C_SDA     = D14,
+   ```
+   
+   to
+   
+   ```
+   I2C_SCL     = PC_0,
+   I2C_SDA     = PC_1,
+   ```
+   
+   This edit is mainly for convenience if your application code uses standard I2C pin names `I2C_SDA` and `I2C_SCL`.
+   
+   You may also choose to add or remove peripherals, add or remove pins, or change the clock frequency by editing `PeripheralNames.h`, `PeripheralPins.c`, or `system_clock.c`.  In our example, for simplicity, we will not edit these files. 
+   
+1. (Optional) Add additional files.
+
+   If necessary, add additional source files for drivers or middleware you have implemented for the new board.  In our example, we do not have any files to add.  
+
+1. (Optional) Add a simple application source file for testing.
+
+    To confirm the software builds for the new target, add a file named `main.cpp` with the following contents.
+
+    ```  
+    #include "mbed.h"
+    
+    DigitalOut led1(LED1);
+
+    int main()
+    {
+        while (true) {
+            led1 = !led1;
+            wait_ms(500);
+        }
+    }
+    ``` 
+
+    This will blink an led.  Just make sure LED1 is defined for the board.
+    
+    Your directory should now look something like this:
+    
+    ```
+    main.cpp
+    custom_target.json
+    TARGET_IMAGINARYBOARD
+    mbed-os
+    .mbed
+    mbed_settings.py
+    mbed-os.lib
+    ```
+    
+1. Compile the project.
+   
+  With the target configuration set and files added, it is ready to compile.  Run the command:
+
+   ```
+   mbed compile -m IMAGINARYBOARD -t <toolchain>
+   ```
+   
+   When successful, it compiles, links and generates a .bin file (or .hex file for some other boards).
+
+   For example, it will print to the screen:
+   ```
+   Image: .\BUILD\IMAGINARYBOARD\GCC_ARM\mbed-os-imaginary-port.bin
+   ```
+
+1. Program the board.  
+
+  You can test this simple example using a `DISCO-L475VG-IOT01A`.  If you actually created a `ImaginaryBoard` board, you could use that too.  
+  
+  <span class="notes">**Note:** Unless your board has an Mbed Enabled debug interface, you need a method of flashing the memory on your board. </span>
+  
+  Since the `DISCO-L475VG-IOT01A` has a Mbed Enabled debug interface (STLink in this case), we can use drag-and-drop programming to flash the board.
+  
+  Locate the binary file and drag it onto the disk drive name for the board (e.g. `DIS_L4IOT`).
+  
+  After the file transfer is complete, press the reset button on the board.  You should see the LED blinking.  
+ 
+1. (Optional) Run automated tests.
+
+  With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port.  Since a new board has a new name that is unknown to the Mbed tools, you will need to tell the tools which `detect_code` to associate it to.  
+  
+  To do this, you can use the `mbedls` `mock` command option.  In our case, we are testing with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its detect code.  If you have a new board that is using a different detect_code, such as `1234`, then use that.  
+  
+  For the `ImaginaryBoard` based on `DISCO-L475VG-IOT01A`, run this command.
+
+  ```
+  mbedls --mock 0764:IMAGINARYBOARD
+  ```
+   
+   <span class="notes">**Note:** Contact the Arm Mbed team to get a unique ID if you plan to have your board coexist with other Mbed Enabled boards while running automated tests.</span>
+
+  Now run the tests, with the following command.
+  
+  ```
+  mbed test -m IMAGINARYBOARD -t <toolchain>
+  ```
+  
+  The tests should start running.
+  
+Now you have successfully ported Mbed OS to a new board.  

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -1,42 +1,42 @@
 # Porting Mbed OS to a custom board
 
-When designing a custom board based on an existing Mbed Enabled board, you will likely need to make configuration and software changes to adapt Mbed OS to run on your new board.  This is often called a software 'port'.  The necessary changes may include adaptations for the unique design choices you have made for your new board, such as clocking, pin connections, and peripheral usage.  This can often be accomplished by adding configuration and source files to an Mbed OS-based application project without the need to modify files within Mbed Os itself.  If you don't plan to push your changes to the upstream Mbed Os repository, this simplifies your software configuration management by allowing you to keep your new files separate.  
+When designing a custom board based on an existing Mbed Enabled board, you may need to make configuration and software changes to adapt Mbed OS to run on your new board. This is called a software port. The necessary changes may include adaptations for the unique design choices you have made for your new board, such as clocking, pin connections and peripheral usage. This can often be accomplished by adding configuration and source files to an Mbed OS-based application project without the need to modify files within `mbed-os`, itself. If you don't plan to push your changes to the upstream `mbed-os` repository, this simplifies your software configuration management by allowing you to keep your new files separate.
 
-Mbed OS supports target inheritance, which allows you to extend an existing microcontroller (MCU) target and just add additional software and configurations required for your board.  If you are using Mbed OS version 5.8 and later, you have the ability to add a file named `custom_target.json` to your project, which can store your custom target configurations without the need to modify `targets.json`.
+Mbed OS supports target inheritance, which allows you to extend an existing microcontroller (MCU) target and just add software and configurations required for your board. You have the ability to add a file named `custom_target.json` to your project, which can store your custom target configurations without the need to modify `targets.json`.
 
-This tutorial provides a quick overview on how to create a custom port using `custom_target.json`.  Not all possible aspects of this process are covered.  For detailed information covering all the ways you can configure targets, go to [adding and configuring targets](../reference/adding-and-configuring-targets.html).
+This tutorial provides a quick overview on how to create a custom port using `custom_target.json`. It covers the most common methods. For detailed information covering all the ways you can configure targets, go to [adding and configuring targets](../reference/adding-and-configuring-targets.html).
 
 ## Extending an existing MCU target configuration
 
-As an example, consider a situation in which you are creating a new board based on an existing Mbed Enabled board.  For this tutorial, consider a new board called `ImaginaryBoard` that is based on [DISCO-L475VG-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/).
+As an example, consider a situation in which you are creating a new board based on an existing Mbed Enabled board. For this tutorial, consider a new board called `ImaginaryBoard` that is based on [DISCO-L475VG-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/).
 
-`ImaginaryBoard` shares most of the same features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN`, `USB` and some pins are connected differently on the new board.   
+`ImaginaryBoard` shares most of the same features of DISCO-L475VG-IOT01A, but it does not use `AnalogOut`, `AnalogIn`, `CAN` or `USB`. Some pins are also connected differently on the new board.
 
-Assuming you have Mbed Command Line Interface (CLI) installed, follow these steps to make the port.
+Assuming you have Mbed CLI installed, follow these steps to make the port.
 
-1. (Optional) Create a new Mbed program (e.g. mbed-os-imaginary-port)
+1. (Optional) Create a new Mbed program (for example, `mbed-os-imaginary-port`).
 
-  If you don't already have an Mbed program on your computer, at a command terminal, run this Mbed CLI command.
+   If you don't already have an Mbed program on your computer, at a command terminal, run this Mbed CLI command:
 
-  ```
-  mbed new --program mbed-os-imaginary-port
+   ```
+   mbed new --program mbed-os-imaginary-port
+   ```
+  
+   This command imports `mbed-os` from the [official Mbed OS source repository](https://github.com/armmbed/mbed-os) into a new directory called `mbed-os-imaginary-port`.
 
-  ```
-  This command will import 'mbed-os' from the [official Mbed OS source repository](https://github.com/armmbed/mbed-os) into a new directory called 'mbed-os-imaginary-port'.
-
-  Now change directories into your new project.  
+   Now, change directories into your new project:  
 
   ```
   cd mbed-os-imaginary-port
   ```
 
-1. Create a new file named `custom_targets.json` at the same level as the `mbed-os` directory.
+1. Create a new file named `custom_targets.json` at the same level as the `mbed-os` directory:
 
-  Inspect the contents of `mbed-os/targets/targets.json`.  For this example, search for `DISCO_L475VG_IOT01A`.  
+   Inspect the contents of `mbed-os/targets/targets.json`. For this example, search for `DISCO_L475VG_IOT01A`.
 
-  Copy the contents from the `DISCO_L475VG_IOT01A` section into your `custom_targets.json` file.  Be sure to include brackets `{ }` sorrounding the content.
+   Copy the contents from the `DISCO_L475VG_IOT01A` section into your `custom_targets.json` file. Be sure to include brackets `{ }` surrounding the content.
 
-  Then make changes for your board.  For example, after making changes, the full contents look like this:
+   Then make changes for your board. For example, after making changes, the full contents look like this:
    
    ```
    {
@@ -85,13 +85,13 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
 
    - The board name was changed from `DISCO_L475VG_IOT01A` to `IMAGINARYBOARD` so the board can be uniquely identified.
 
-   - The `detect_code` was changed from `0764` to `1234`.  The `detect_code` is a unique number that identifies the board to the Mbed OS test tools.  This number is typically built into the debug interface.  
+   - The `detect_code` was changed from `0764` to `1234`. The `detect_code` is a unique number that identifies the board to the Mbed OS test tools. This number is typically built into the debug interface.
 
    - The `macros_add` section was changed to remove `USBHOST_OTHER` because USB is not used on the new board.
 
-   - The `device_has_add` section was changed to not add the  `ANALOGOUT`, `CAN`, `USBDEVICE` drivers because those features are not used on the new board.
+   - The `device_has_add` section was changed to not add the `ANALOGOUT`, `CAN`, `USBDEVICE` drivers because those features are not used on the new board.
 
-   - A new section, `device_has_remove`, was added.  This removes `ANALOGIN`, `I2CSLAVE`, and `I2C_ASYNCH` drivers because these features are also not used.  The reason why `device_has_remove` is used in this case is because the board is inheriting from the MCU Family configuration `FAMILY_STM32`, which has those drivers added by default.
+   - A new section, `device_has_remove`, was added. This removes `ANALOGIN`, `I2CSLAVE`, and `I2C_ASYNCH` drivers because these features are also not used.  The reason why `device_has_remove` is used in this case is because the board is inheriting from the MCU Family configuration `FAMILY_STM32`, which has those drivers added by default.
 
    All the other configurations for the board are inherited from the MCU Family configuration called `FAMILY_STM32`.  
 
@@ -105,22 +105,22 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
 
 ## Configuring the target code directories
 
-  In some cases, the target source code directories follow a similar structure as the target configuration, but they could have a few more levels.  
+In some cases, the target source code directories follow a similar structure as the target configuration, but they could have a few more levels.
 
-  For example, in the `mbed-os/targets` folder, the target directories for DISCO_L475VG_IOT01A follow this pattern:
+For example, in the `mbed-os/targets` folder, the target directories for DISCO_L475VG_IOT01A follow this pattern:
 
-  ```
-  mbed-os
-      |_targets
-            |_TARGET_STM            <- MCU VENDOR
-            |      |_TARGET_STM32L4             <- MCU FAMILY
-            |             |_TARGET_STM32L475xG               <- MCU
-            |                    |_TARGET_DISCO_L475VG_IOT01A     <- Board
-  ```
+   ```
+   mbed-os
+       |_targets
+             |_TARGET_STM            <- MCU VENDOR
+             |      |_TARGET_STM32L4             <- MCU FAMILY
+             |             |_TARGET_STM32L475xG               <- MCU
+             |                    |_TARGET_DISCO_L475VG_IOT01A     <- Board
+   ```
 
-  Boards typically inherit files that support the MCU, MCU family, and MCU vendor.  When adding a new board, you need to add a new set of files for the board.
+Boards typically inherit files that support the MCU, MCU family and MCU vendor. When adding a new board, you need to add a new set of files for the board.
 
-  You may be wondering why there are more directory levels than target configuration levels.  This is because many targets utilize the `extra_labels_add` feature in the target configuration.  The following keywords `STM32L4`, `STM32L475xG`, `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG`, `TARGET_STM32L475VG` respectively.  With those labels applied, these directory names get included in the build for this target.  
+You may be wondering why there are more directory levels than target configuration levels. This is because many targets use the `extra_labels_add` feature in the target configuration. The following keywords `STM32L4`, `STM32L475xG`, `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG`, `TARGET_STM32L475VG` respectively. With those labels applied, these directory names get included in the build for this target.
 
 1. Create a new directory called `TARGET_IMAGINARYBOARD` at the top level of your project.
    
@@ -137,7 +137,7 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
    
 1. Now place source files for the board.
    
-   Inspect the files at `mbed-os\targets\TARGET_STM\TARGET_STM32L4\TARGET_STM32L475xG\TARGET_DISCO_L475VG_IOT01A`.  You should find the following files or similar.  
+   Inspect the files at `mbed-os\targets\TARGET_STM\TARGET_STM32L4\TARGET_STM32L475xG\TARGET_DISCO_L475VG_IOT01A`. You should find the following files or similar:
    
    `PeripheralNames.h`, `PeripheralPins.c`, `PinNames.h`, `system_clock.c`
    
@@ -145,14 +145,14 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
    
    The files provide these capabilities.
       
-   - `PeripheralNames.h` describes the available peripherals and their base addresses
-   - `PeripheralPins.c` describes the available pins and their association with peripherals 
+   - `PeripheralNames.h` describes the available peripherals and their base addresses.
+   - `PeripheralPins.c` describes the available pins and their association with peripherals.
    - `PinNames.h` sets macros for pins that define their function.
-   - `system_clock.c` vendor specific file that initializes the system and sets up the clocks
+   - `system_clock.c` vendor specific file that initializes the system and sets up the clocks.
       
 1. Modify the files.
 
-   `PinNames.h` is the most common file to be edited.  For our example, the ImaginaryBoard is using I2C but connected to different supported signals.  Change the I2C pin macro definitions from:
+   `PinNames.h` is the most common file to be edited. For our example, the ImaginaryBoard is using I2C but connected to different supported signals. Change the I2C pin macro definitions from:
    
    ```
    I2C_SCL     = D15,
@@ -168,15 +168,15 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
    
    This edit is mainly for convenience if your application code uses standard I2C pin names `I2C_SDA` and `I2C_SCL`.
    
-   You may also choose to add or remove peripherals, add or remove pins, or change the clock frequency by editing `PeripheralNames.h`, `PeripheralPins.c`, or `system_clock.c`.  In our example, for simplicity, we will not edit these files. 
+   You may also choose to add or remove peripherals, add or remove pins or change the clock frequency by editing `PeripheralNames.h`, `PeripheralPins.c` or `system_clock.c`. In our example, for simplicity, we will not edit these files.
    
 1. (Optional) Add additional files.
 
-   If necessary, add additional source files for drivers or middleware you have implemented for the new board.  In our example, we do not have any files to add.  
+   If necessary, add additional source files for drivers or middleware you have implemented for the new board. In our example, we do not have any files to add.
 
 1. (Optional) Add a simple application source file for testing.
 
-    To confirm the software builds for the new target, add a file named `main.cpp` with the following contents.
+    To confirm the software builds for the new target, add a file named `main.cpp` with the following contents:
 
     ```  
     #include "mbed.h"
@@ -192,9 +192,9 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
     }
     ``` 
 
-    This will blink an led.  Just make sure LED1 is defined for the board.
+    This blinks an LED. Just make sure LED1 is defined for the board.
     
-    Your directory should now look something like this:
+    Your directory now looks something like this:
     
     ```
     main.cpp
@@ -208,36 +208,37 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
     
 1. Compile the project.
    
-  With the target configuration set and files added, it is ready to compile.  Run the command:
+  With the target configuration set and files added, it is ready to compile. Run the command:
 
    ```
    mbed compile -m IMAGINARYBOARD -t <toolchain>
    ```
    
-   When successful, it compiles, links and generates a .bin file (or .hex file for some other boards).
+   When successful, it compiles, links and generates a `.bin` file (or `.hex` file for some other boards).
 
-   For example, it will print to the screen:
+   For example, it prints to the screen:
+   
    ```
    Image: .\BUILD\IMAGINARYBOARD\GCC_ARM\mbed-os-imaginary-port.bin
    ```
 
 1. Program the board.  
 
-  You can test this simple example using a `DISCO-L475VG-IOT01A`.  If you actually created a `ImaginaryBoard` board, you could use that too.  
+  You can test this simple example using a `DISCO-L475VG-IOT01A`. If you actually created a `ImaginaryBoard` board, you could use that too.  
   
   <span class="notes">**Note:** Unless your board has an Mbed Enabled debug interface, you need a method of flashing the memory on your board. </span>
   
   Since the `DISCO-L475VG-IOT01A` has a Mbed Enabled debug interface (STLink in this case), we can use drag-and-drop programming to flash the board.
   
-  Locate the binary file and drag it onto the disk drive name for the board (e.g. `DIS_L4IOT`).
+  Locate the binary file and drag it onto the disk drive name for the board (for example, `DIS_L4IOT`).
   
-  After the file transfer is complete, press the reset button on the board.  You should see the LED blinking.  
+  After the file transfer is complete, press the reset button on the board. You should see the LED blinking.
  
 1. (Optional) Run automated tests.
 
-  With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port.  Since a new board has a new name that is unknown to the Mbed tools, you will need to tell the tools which `detect_code` to associate it to.  
+  With an Mbed Enabled debug interface, you can also run the Mbed OS automated tests on your port. Since a new board has a new name that is unknown to the Mbed tools, you will need to tell the tools which `detect_code` to associate it to.
   
-  To do this, you can use the `mbedls` `mock` command option.  In our case, we are testing with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its detect code.  If you have a new board that is using a different detect_code, such as `1234`, then use that.  
+  To do this, you can use the `mbedls` `mock` command option. In our case, we are testing with a `DISCO-L475VG-IOT01A`, which has a debug interface that exposes `0764` as its detect code. If you have a new board that is using a different detect_code, such as `1234`, then use that.
   
   For the `ImaginaryBoard` based on `DISCO-L475VG-IOT01A`, run this command.
 
@@ -255,4 +256,4 @@ Assuming you have Mbed Command Line Interface (CLI) installed, follow these step
   
   The tests should start running.
   
-Now you have successfully ported Mbed OS to a new board.  
+Now you have successfully ported Mbed OS to a new board.

--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -120,7 +120,7 @@ For example, in the `mbed-os/targets` folder, the target directories for DISCO_L
 
 Boards typically inherit files that support the MCU, MCU family and MCU vendor. When adding a new board, you need to add a new set of files for the board.
 
-You may be wondering why there are more directory levels than target configuration levels. This is because many targets use the `extra_labels_add` feature in the target configuration. The following keywords `STM32L4`, `STM32L475xG`, `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG`, `TARGET_STM32L475VG` respectively. With those labels applied, these directory names get included in the build for this target.
+You may be wondering why there are more directory levels than target configuration levels. This is because many targets use the `extra_labels_add` feature in the target configuration. The keywords `STM32L4`, `STM32L475xG`, `STM32L475VG` resolve to `TARGET_STM32L4`, `TARGET_STM32L475xG`, `TARGET_STM32L475VG` respectively. With those labels applied, these directory names get included in the build for this target.
 
 1. Create a new directory called `TARGET_IMAGINARYBOARD` at the top level of your project.
    


### PR DESCRIPTION
Add tutorial about porting Mbed OS to a custom board.

This replaces https://github.com/ARMmbed/mbed-os-5-docs/pull/1130.

Due to difficulty rebasing the previous PR, I went ahead and created a new one.  

I rewrote the document based on feedback received.  My goal was to provide more clarity and helpful details.   

There might be formatting issues.  Pleases review and let me know what I should fix.
