### PR TITLE
Update the watchdog timing requirements

### DIFF
--- a/docs/porting/target/Watchdog.md
+++ b/docs/porting/target/Watchdog.md
@@ -11,7 +11,8 @@ Implement the ResetReason API when implementing the Watchdog API. The ResetReaso
 - Sleep and debug modes don't stop the watchdog timer from counting down.
 - The function `hal_watchdog_init` is safe to call repeatedly. The function's implementation must not do anything if `hal_watchdog_init` has already initialized the hardware watchdog timer.
 - `UINT32_MAX` milliseconds is the maximum allowed max_timeout `hal_watchdog_get_platform_features()` returns; minimum timeout is 1 ms.
-- The watchdog should trigger at or after the timeout value.
+- The uncalibrated watchdog should trigger at or after the timeout value multiplied by the frequency accuracy ratio of its oscillator (typical_frequency / max_frequency).
+- The calibrated watchdog should trigger at or after the timeout value.
 - The watchdog should trigger before twice the timeout value.
 
 ### Undefined behavior

--- a/docs/porting/target/Watchdog.md
+++ b/docs/porting/target/Watchdog.md
@@ -14,6 +14,7 @@ Implement the ResetReason API when implementing the Watchdog API. The ResetReaso
 - The uncalibrated watchdog should trigger at or after the timeout value multiplied by the frequency accuracy ratio of its oscillator (typical_frequency divided by max_frequency).
 - The calibrated watchdog should trigger at or after the timeout value.
 - The watchdog should trigger before twice the timeout value.
+- The watchdog may trigger as late as twice the timeout value in deepsleep mode.
 
 ### Undefined behavior
 

--- a/docs/porting/target/Watchdog.md
+++ b/docs/porting/target/Watchdog.md
@@ -14,7 +14,7 @@ Implement the ResetReason API when implementing the Watchdog API. The ResetReaso
 - The uncalibrated watchdog should trigger at or after the timeout value multiplied by the frequency accuracy ratio of its oscillator (typical_frequency divided by max_frequency).
 - The calibrated watchdog should trigger at or after the timeout value.
 - The watchdog should trigger before twice the timeout value.
-- The watchdog may trigger as late as twice the timeout value in deepsleep mode.
+- The watchdog may trigger as late as twice the timeout value in deep sleep mode.
 
 ### Undefined behavior
 

--- a/docs/porting/target/Watchdog.md
+++ b/docs/porting/target/Watchdog.md
@@ -11,7 +11,7 @@ Implement the ResetReason API when implementing the Watchdog API. The ResetReaso
 - Sleep and debug modes don't stop the watchdog timer from counting down.
 - The function `hal_watchdog_init` is safe to call repeatedly. The function's implementation must not do anything if `hal_watchdog_init` has already initialized the hardware watchdog timer.
 - `UINT32_MAX` milliseconds is the maximum allowed max_timeout `hal_watchdog_get_platform_features()` returns; minimum timeout is 1 ms.
-- The uncalibrated watchdog should trigger at or after the timeout value multiplied by the frequency accuracy ratio of its oscillator (typical_frequency / max_frequency).
+- The uncalibrated watchdog should trigger at or after the timeout value multiplied by the frequency accuracy ratio of its oscillator (typical_frequency divided by max_frequency).
 - The calibrated watchdog should trigger at or after the timeout value.
 - The watchdog should trigger before twice the timeout value.
 


### PR DESCRIPTION
Update the requirements according to https://github.com/ARMmbed/mbed-os/pull/11203, that differentiates lower timeout limit for calibrated and uncalibrated watchdog clock.

This should wait until https://github.com/ARMmbed/mbed-os/pull/11203 is merged to Mbed OS repo.