### PR TITLE
Keil MDK 5.27 -> Keil MDK 5.28a

### DIFF
--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -38,7 +38,7 @@ Mbed OS 5 can be built with various toolchains. The currently supported versions
 
 - Arm Compiler 6.11 (default ARM toolchain).
   - A paid version is available as [Arm Compiler 6.11 Professional](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6).
-  - A paid version is also included in [Keil MDK 5.27](http://www2.keil.com/mdk5/).
+  - A paid version is also included in [Keil MDK 5.28a](http://www2.keil.com/mdk5/).
 - [Arm Compiler 5.06 update 6 (to be deprecated in the future)](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads).
 - [GNU Arm Embedded version  6 (6-2017-q1-update)](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
 - [IAR Embedded Workbench 8.32.1](https://iar.com/mbed).


### PR DESCRIPTION
Mbed OS 5.14 needs 5.28a - see
https://github.com/ARMmbed/mbed-os/pull/11225