### PR TITLE
workflow: make more verbose that bugs come to Github

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -33,7 +33,7 @@ Please create separate pull requests for each topic; each pull request needs a c
 
 ### Reporting bugs
 
-You can submit Mbed OS bugs on the [forums](https://os.mbed.com/forum/bugs-suggestions/) or directly on [GitHub](https://github.com/ARMmbed/mbed-os).
+You can submit Mbed OS bugs directly on [GitHub](https://github.com/ARMmbed/mbed-os). Questions or enhancement requests should be submitted on the [forums](https://os.mbed.com/forum/bugs-suggestions/).
 
 The bug report should be reproducible (fails for others) and specific (where and how it fails). We will close insufficient bug reports.
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -33,7 +33,7 @@ Please create separate pull requests for each topic; each pull request needs a c
 
 ### Reporting bugs
 
-You can submit Mbed OS bugs directly on [GitHub](https://github.com/ARMmbed/mbed-os). Questions or enhancement requests should be submitted on the [forums](https://os.mbed.com/forum/bugs-suggestions/).
+You can submit Mbed OS bugs directly on [GitHub](https://github.com/ARMmbed/mbed-os). Please submit questions or enhancement requests on the [forums](https://os.mbed.com/forum/bugs-suggestions/).
 
 The bug report should be reproducible (fails for others) and specific (where and how it fails). We will close insufficient bug reports.
 


### PR DESCRIPTION
Questions/Enhancements go to forum. This follows the latest update to our issue
workflow update.

More info https://os.mbed.com/blog/entry/Improving-the-management-of-community-in/

cc @ARMmbed/mbed-os-maintainers 

@AnotherButler We should encourage users to use Github for technical issues and anything else go to our forum. Please review and edit 