### PR TITLE
Move related links to quick-start-compiler.md

### DIFF
--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -44,3 +44,9 @@ Alternatively, you may select the import button on the top left hand side of the
 1. Open the folder where the executable file was downloaded, and then click and drag (or copy and paste) the file to your Mbed board's USB device folder.
 
 1. Press the board's reset button.
+
+## Related links
+
+- [Mbed OS statistics API](../apis/mbed-statistics.html).
+- [Mbed OS configuration](../reference/configuration.html).
+- [Mbed OS serial communication](../tutorials/serial-communication.html).


### PR DESCRIPTION
Move related links to this page because the example walkthrough content is no longer relevant to the quick start example.