### PR TITLE
Move related links to cli_code.md

### DIFF
--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -30,3 +30,9 @@
    ```
 
 1. Press the board's reset button. The LED blinks.
+
+## Related links
+
+- [Mbed OS statistics API](../apis/mbed-statistics.html).
+- [Mbed OS configuration](../reference/configuration.html).
+- [Mbed OS serial communication](../tutorials/serial-communication.html).


### PR DESCRIPTION
Move related links to this page because the example walkthrough content is no longer relevant to the quick start example.