### PR TITLE
Add small clarifications related to unique board IDs

### DIFF
--- a/docs/porting/porting_full_process/porting_reqs.md
+++ b/docs/porting/porting_full_process/porting_reqs.md
@@ -10,8 +10,7 @@ Porting Mbed OS requires the following hardware:
 - A micro SD card for the CI test shield.
 - A USB cable to connect the evaluation board to your development PC.
 
-
-<span class="notes">**Note:** The new target needs a unique board ID. To get one, please contact your technical account manager or email [our support team](mailto:support@mbed.com).</span>
+<span class="notes">**Note:** If you intend to release a new target to the Mbed community, it needs a unique four-digit hexadecimal identifier called a Platform ID. To get one, please contact your technical account manager or email [our support team](mailto:support@mbed.com).</span>
 
 If there is no interface MCU on the board you may also need:
 

--- a/docs/porting/tools/mbedls.md
+++ b/docs/porting/tools/mbedls.md
@@ -6,7 +6,7 @@ Mbed-ls is a Python module that detects and lists Mbed Enabled boards connected 
 
 Mbed-ls needs the following information to correctly detect an Mbed Enabled board:
 
- - A four-digit hexadecimal identifier of a board class.
+ - A four-digit hexadecimal identifier of a board class called a Platform ID.
  - A vendor string for detection on Windows.
 
 Further, Mbed-ls only detects devices that meet the following criteria:


### PR DESCRIPTION
Align to terminology 'Platform ID' used by MbedLS documentation on GitHub.