### PR TITLE
Enabling bare metal

### DIFF
--- a/docs/reference/bare_metal/baremetal_example.md
+++ b/docs/reference/bare_metal/baremetal_example.md
@@ -1,16 +1,6 @@
 # Bare metal example
 
-## Enabling Mbed OS bare metal
-
-You can enable Mbed OS bare metal by creating an `mbed_app.json` with the following contents:
-
-```
-{
-    "requires": ["bare-metal"]
-}
-```
-
-## Bare metal example
+To use this example, [enable bare metal](../tutorials/migrating-to-mbed-os-5.html#enabling-bare-metal).
 
 To learn about using the bare metal profile on Mbed OS 5, please see the Blinky bare metal example:
 

--- a/docs/reference/bare_metal/baremetal_example.md
+++ b/docs/reference/bare_metal/baremetal_example.md
@@ -1,6 +1,12 @@
 # Bare metal example
 
-To use this example, [enable bare metal](../tutorials/migrating-to-mbed-os-5.html#enabling-bare-metal).
+To enable Mbed OS bare metal, create an `mbed_app.json` with the following contents:
+
+```
+{
+    "requires": ["bare-metal"]
+}
+```
 
 To learn about using the bare metal profile on Mbed OS 5, please see the Blinky bare metal example:
 

--- a/docs/reference/bare_metal/baremetal_example.md
+++ b/docs/reference/bare_metal/baremetal_example.md
@@ -1,5 +1,17 @@
 # Bare metal example
 
+## Enabling Mbed OS bare metal
+
+You can enable Mbed OS bare metal by creating an `mbed_app.json` with the following contents:
+
+```
+{
+    "requires": ["bare-metal"]
+}
+```
+
+## Bare metal example
+
 To learn about using the bare metal profile on Mbed OS 5, please see the Blinky bare metal example:
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/armmbed/mbed-os-example-blinky-baremetal/)](https://github.com/armmbed/mbed-os-example-blinky-baremetal/blob/master/main.cpp)


### PR DESCRIPTION
Information on how to enable bare metal is missing from this page (although it can be found here: https://os.mbed.com/docs/mbed-os/v5.14/tutorials/migrating-to-mbed-os-5.html)