### PR TITLE
SharedPtr: NULL -> nullptr

### DIFF
--- a/docs/api/platform/SharedPtr.md
+++ b/docs/api/platform/SharedPtr.md
@@ -27,8 +27,8 @@ void test() {
     // Increase reference count
     SharedPtr<MyStruct> ptr2( ptr );
 
-    ptr = NULL; // Reference to the struct instance is still held by ptr2
+    ptr = nullptr; // Reference to the struct instance is still held by ptr2
 
-    ptr2 = NULL; // The raw pointer is freed
+    ptr2 = nullptr; // The raw pointer is freed
 }
 ```


### PR DESCRIPTION
https://github.com/ARMmbed/mbed-os/pull/12048 will require that `SharedPtr` users use `nullptr` rather than `NULL` or `0`, which will no longer compile.

Update example in code.

Change can be made to docs whenever, as `nullptr` form works now.