### PR TITLE
workflow: add 3rd party updates as an exception

### DIFF
--- a/docs/contributing/guidelines/workflow.md
+++ b/docs/contributing/guidelines/workflow.md
@@ -53,7 +53,7 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 - Avoid merging commmits. (Always rebase when possible.)
 - Comment in the pull request on every change (rebase or new commits). This helps reviewers to be up to date with changes
 - Pull requests should fix a bug, add a feature or refactor.
-   The only exception are third-party version updates (for example, Mbed TLS or Nanostack releases for Mbed OS). These updates should provide Mbed OS release notes in the pull request description, or link to an external changelog or release notes.
+   The only exceptions are third-party version updates (for example, Mbed TLS or Nanostack releases for Mbed OS). These updates should provide Mbed OS release notes in the pull request description, or link to an external changelog or release notes.
 - Smaller pull requests are easier to review and faster to integrate. Use dependencies – split your work by pull request type or functional changes. To add a third-party driver, send it in a separate pull request, and add it as a dependency to your pull request.
 
 If commits do not follow the above guidelines, we may request that you modify the commit history (often to add more details to address _what_ and _why_ rather than _how_).

--- a/docs/contributing/guidelines/workflow.md
+++ b/docs/contributing/guidelines/workflow.md
@@ -52,8 +52,8 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 - All new features and enhancements require documentation, tests and user guides for us to accept them. Please link each pull request to all relevant documentation and test pull requests.
 - Avoid merging commmits. (Always rebase when possible.)
 - Comment in the pull request on every change (rebase or new commits). This helps reviewers to be up to date with changes
-- Pull requests should fix a bug, add a feature or refactor. 
-  The only exception are third-party version updates (for instance MbedTLS or Nanostack releases for Mbed OS). These updates should provide release notes for updated version with documentation (a reference to external changelog or release notes).
+- Pull requests should fix a bug, add a feature or refactor.
+   The only exception are third-party version updates (for example, Mbed TLS or Nanostack releases for Mbed OS). These updates should provide Mbed OS release notes in the pull request description, or link to an external changelog or release notes.
 - Smaller pull requests are easier to review and faster to integrate. Use dependencies – split your work by pull request type or functional changes. To add a third-party driver, send it in a separate pull request, and add it as a dependency to your pull request.
 
 If commits do not follow the above guidelines, we may request that you modify the commit history (often to add more details to address _what_ and _why_ rather than _how_).

--- a/docs/contributing/guidelines/workflow.md
+++ b/docs/contributing/guidelines/workflow.md
@@ -52,7 +52,8 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 - All new features and enhancements require documentation, tests and user guides for us to accept them. Please link each pull request to all relevant documentation and test pull requests.
 - Avoid merging commmits. (Always rebase when possible.)
 - Comment in the pull request on every change (rebase or new commits). This helps reviewers to be up to date with changes
-- Pull requests should fix a bug, add a feature or refactor.
+- Pull requests should fix a bug, add a feature or refactor. 
+  The only exception are third-party version updates (for instance MbedTLS or Nanostack releases for Mbed OS). These updates should provide release notes for updated version with documentation (a reference to external changelog or release notes).
 - Smaller pull requests are easier to review and faster to integrate. Use dependencies – split your work by pull request type or functional changes. To add a third-party driver, send it in a separate pull request, and add it as a dependency to your pull request.
 
 If commits do not follow the above guidelines, we may request that you modify the commit history (often to add more details to address _what_ and _why_ rather than _how_).


### PR DESCRIPTION
Updates like MbedTLS might contain more than just a bugfix. To keep it simple, they should be sent as one PR - version update. Splitting this type of updates makes it difficult to maintain.

This was missing the guidelines - version updates should not be separated. Would it be sufficient to note there as it is now, or rather to dedicate it entire section (also add how to add subtree - as nanostack is doing ?).

@ARMmbed/mbed-os-maintainers Please review