### PR TITLE
Update link to TCPSockets example to mbed-os-5.15

### DIFF
--- a/docs/api/networksocket/TCPSocket.md
+++ b/docs/api/networksocket/TCPSocket.md
@@ -26,7 +26,7 @@ Accepting a connection leaves the original socket in listening mode. You can con
 
 Here is a client example of HTTP transaction over TCPSocket:
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-sockets)](https://github.com/ARMmbed/mbed-os-example-sockets/blob/mbed-os-5.14/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-sockets)](https://github.com/ARMmbed/mbed-os-example-sockets/blob/mbed-os-5.15/main.cpp)
 
 ## Related content
 


### PR DESCRIPTION
As @JanneKiiskila noticed we are presenting deprecated API in our official mbed-os-5.15 documentation: https://os.mbed.com/docs/mbed-os/v5.15/apis/tcpsocket.html#tcpsocket-example

This PR updates the `development` branch, but we would like it to go to mbed-os-5.15 branch as well. @AnotherButler , is it OK if I open another PR to `v5.15`, or should I modify this one to go straight to `v5.15`? I thought it's best to start with updating `development` and then cherry-picking it to release branch, but if there is a better way, please let me know.