### PR TITLE
Remove leading slash from redirect value v5.14

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1,5 +1,5 @@
 {
-  "reference/mesh-tech.html" : "/reference/6LoWPAN-ND-tech.html",
+  "reference/mesh-tech.html" : "reference/6LoWPAN-ND-tech.html",
   "tools/windows.html" : "tools/installation-and-setup.html",
   "tools/macos.html" : "tools/installation-and-setup.html",
   "tools/linux.html" : "tools/manual-installation.html",


### PR DESCRIPTION
The redirects functionality does not handle redirects that have a leading slash such as this one (this will just lead to a page error at the moment).
