### PR TITLE
Fix config option check example

### DIFF
--- a/docs/migrating/mbed-os-2-vs-5.md
+++ b/docs/migrating/mbed-os-2-vs-5.md
@@ -18,7 +18,7 @@ To migrate from Mbed OS 2 to Mbed OS 5, [please follow our migration tutorial](.
    Yes. Inside the `mbed.h` file in your Mbed OS project, you can see `if` statements that look at `MBED_CONF` variables. The `mbed_lib.json` files located in their respective Mbed OS directory define these variables. For example, in `mbed.h` you can find the following lines:
 
    ```
-   #if MBED_CONF_RTOS_PRESENT
+   #if MBED_CONF_RTOS_API_PRESENT
    #include "rtos/rtos.h"
    #endif
    ```


### PR DESCRIPTION
Fix the configuration check of `MBED_CONF_RTOS_PRESENT` to
`MBED_CONF_RTOS_API_PRESENT` to align to the [code](https://github.com/ARMmbed/mbed-os/blob/master/mbed.h#L21).
Reported by Email from 王高腾