### PR TITLE
Add license PR checks + how to run it locally

### DIFF
--- a/docs/contributing/guidelines/ci.md
+++ b/docs/contributing/guidelines/ci.md
@@ -24,7 +24,7 @@ Travis configuration is located in the [.travis.yml](https://github.com/ARMmbed/
    - Features/netsocket.
 - **travis-ci/events** - Checks that Mbed OS compiles and run events tests.
 - **travis-ci/gitattributestest** - Checks there are no changes after clone. This checks that `.gitattributes` is used correctly.
-- **travis-ci/licence_check** - Checks there is only permissive license in files, including SPDX identifier.
+- **travis-ci/licence_check** - Checks only a permissive license in the files, including SPDX identifier.
 - **travis-ci/littlefs** - Tests littlefs without embedded hardware.
 - **travis-ci/tools-py2.7** - Runs Python tools tests with Python 2.7.
 - **travis-ci/psa-autogen** - Runs PSA SPM code generator.

--- a/docs/contributing/guidelines/ci.md
+++ b/docs/contributing/guidelines/ci.md
@@ -24,7 +24,7 @@ Travis configuration is located in the [.travis.yml](https://github.com/ARMmbed/
    - Features/netsocket.
 - **travis-ci/events** - Checks that Mbed OS compiles and run events tests.
 - **travis-ci/gitattributestest** - Checks there are no changes after clone. This checks that `.gitattributes` is used correctly.
-- **travis-ci/licence_check** - Checks there is no GPL license text in the code.
+- **travis-ci/licence_check** - Checks there is only permissive license in files, including SPDX identifier.
 - **travis-ci/littlefs** - Tests littlefs without embedded hardware.
 - **travis-ci/tools-py2.7** - Runs Python tools tests with Python 2.7.
 - **travis-ci/psa-autogen** - Runs PSA SPM code generator.

--- a/docs/contributing/guidelines/ci.md
+++ b/docs/contributing/guidelines/ci.md
@@ -24,7 +24,7 @@ Travis configuration is located in the [.travis.yml](https://github.com/ARMmbed/
    - Features/netsocket.
 - **travis-ci/events** - Checks that Mbed OS compiles and run events tests.
 - **travis-ci/gitattributestest** - Checks there are no changes after clone. This checks that `.gitattributes` is used correctly.
-- **travis-ci/licence_check** - Checks only a permissive license in the files, including SPDX identifier.
+- **travis-ci/licence_check** - Checks that there is only a permissive license in the files, including SPDX identifier.
 - **travis-ci/littlefs** - Tests littlefs without embedded hardware.
 - **travis-ci/tools-py2.7** - Runs Python tools tests with Python 2.7.
 - **travis-ci/psa-autogen** - Runs PSA SPM code generator.

--- a/docs/contributing/guidelines/license.md
+++ b/docs/contributing/guidelines/license.md
@@ -4,8 +4,6 @@ This chapter covers the different aspects of developing your own libraries for u
 - [Creating and licensing](#licensing-binaries-and-libraries): Create and license your own binaries and libraries.
 - [The Arm Mbed OS codebase](#contributing-to-the-mbed-os-codebase): Use GitHub to contribute additions and bug fixes to Mbed OS itself.
 
-We use scancode-toolkit to enforce the license in binaries and libraries. Please see "Continuous integration (CI) testing" section for more information.
-
 ## Licensing binaries and libraries
 
 When you write original code, you own the copyright and can choose to make it available to others under a license of your choice. A license gives rights and puts limitations on the reuse of your code by others. Not having a license means others cannot use your code. We encourage you to choose a license that makes possible (and encourages!) reuse by others.
@@ -104,6 +102,22 @@ If you decide to use a different license for your work, follow the same pattern:
 - Begin each source header with your copyright line, the SPDX identifier and the standard header for the license that applies to that single file, if it has one. (See [SPDX Specification, Appendix V](https://spdx.org/spdx-specification-21-web-version#h.twlc0ztnng3b).)
 
 - If more than one license applies to the source file, use an SPDX license expression (see [SPDX Specification, Appendix IV](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60)), to reflect the presence of multiple licenses in your *LICENSE.md* file and in each source file.
+
+## License check in pull requests
+
+We use scancode-toolkit to enforce the license in binaries and libraries. Please see "Continuous integration (CI) testing" section for more information.
+
+To scan the files in SCANCODE folder, please use:
+
+```
+scancode --license --json-pp mbed-os.json SCANCODE
+```
+
+Run our script to check if files confirm to this license guide:
+
+```
+python tools/test/travis-ci/scancode-evaluate.py -f mbed-os.json
+```
 
 ## Contributing to the Mbed OS codebase
 

--- a/docs/contributing/guidelines/license.md
+++ b/docs/contributing/guidelines/license.md
@@ -107,7 +107,7 @@ If you decide to use a different license for your work, follow the same pattern:
 
 We use scancode-toolkit to enforce the license in binaries and libraries. Please see "Continuous integration (CI) testing" section for more information.
 
-To scan the files in SCANCODE folder, please use:
+To scan the files in the SCANCODE folder, please use:
 
 ```
 scancode --license --json-pp mbed-os.json SCANCODE

--- a/docs/contributing/guidelines/license.md
+++ b/docs/contributing/guidelines/license.md
@@ -4,6 +4,8 @@ This chapter covers the different aspects of developing your own libraries for u
 - [Creating and licensing](#licensing-binaries-and-libraries): Create and license your own binaries and libraries.
 - [The Arm Mbed OS codebase](#contributing-to-the-mbed-os-codebase): Use GitHub to contribute additions and bug fixes to Mbed OS itself.
 
+We use scancode-toolkit to enforce the license in binaries and libraries. Please see "Continuous integration (CI) testing" section for more information.
+
 ## Licensing binaries and libraries
 
 When you write original code, you own the copyright and can choose to make it available to others under a license of your choice. A license gives rights and puts limitations on the reuse of your code by others. Not having a license means others cannot use your code. We encourage you to choose a license that makes possible (and encourages!) reuse by others.


### PR DESCRIPTION
This depends on https://github.com/ARMmbed/mbed-os/pull/12437
Once it is merged, this can go in (no release dependency, will be running on master for every PR)

I added a section to our license guide - how to run the license check

@ARMmbed/mbed-os-maintainers Please review