### PR TITLE
Update the version of example to 5.15

### DIFF
--- a/docs/api/networksocket/TLSSocket.md
+++ b/docs/api/networksocket/TLSSocket.md
@@ -14,7 +14,7 @@ To use secure TLS connections, the application uses the `TLSSocketWrapper` throu
 
 The TLSSocket example creates TLS connection to the HTTPS server and receives a simple response from the server:
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-tls-socket/blob/master/)](https://github.com/ARMmbed/mbed-os-example-tls-socket/blob/mbed-os-5.14/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-tls-socket/blob/master/)](https://github.com/ARMmbed/mbed-os-example-tls-socket/blob/mbed-os-5.15/main.cpp)
 
 ## Related content
 


### PR DESCRIPTION
Update the link of the example code for TLS Socket to 5.15,
as current documentation refers to this version.

Note that this version code has a bug in it, but already fixed, and will probably be updated with 5.16 version, so need to  stay tuned on this.
References:
* https://github.com/ARMmbed/mbed-os-example-tls-socket/issues/48
* https://forums.mbed.com/t/warning-connect-is-deprecated-string-based-apis-are-deprecated-since-mbed-os-5-15/7347