### PR TITLE
rename events example

### DIFF
--- a/docs/api/rtos/Event.md
+++ b/docs/api/rtos/Event.md
@@ -12,7 +12,7 @@ The Event class is thread safe. The `post` and `cancel` APIs are IRQ safe.
 
 The code below demonstrates how you can instantiate, configure and post events.
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/mbed-os-example-events/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/mbed-os-example-events/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/Events_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/Events_ex_1/main.cpp)
 
 ## Related content
 


### PR DESCRIPTION
rename to fit naming convention
example PR: https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/82