### PR TITLE
update example snippets links

### DIFF
--- a/docs/api/io/PortIn.md
+++ b/docs/api/io/PortIn.md
@@ -14,7 +14,7 @@ The device-specific `PinNames.h` and the respective datasheet or reference manua
 
 ## PortIn hello, world
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/users/mbed_official/code/PortIn_HelloWorld/)](https://os.mbed.com/teams/mbed_example/code/PortIn_HelloWorld/file/e78266d48649/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Drivers/PortIn_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Drivers/PortIn_ex_1/main.cpp)
 
 ## Related content
 

--- a/docs/api/io/PortInOut.md
+++ b/docs/api/io/PortInOut.md
@@ -10,7 +10,7 @@ A mask can be supplied so you only use certain parts of a port, allowing other b
 
 ## PortInOut hello, world
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/users/mbed_official/code/PortInOut_HelloWorld/)](https://os.mbed.com/teams/mbed_example/code/PortInOut_HelloWorld/file/3f1944b9de6a/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Drivers/PortInOut_ex_1/main.cpp)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Drivers/PortInOut_ex_1/main.cpp)
 
 ## Related content
 

--- a/docs/api/io/PortOut.md
+++ b/docs/api/io/PortOut.md
@@ -14,7 +14,7 @@ The device-specific `PinNames.h` and the respective datasheet or reference manua
 
 ## PortOut hello, world
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/PortOut_HelloWorld/)](https://os.mbed.com/teams/mbed_example/code/PortOut_HelloWorld/file/e4e6fab14d21/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Drivers/PortOut_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Drivers/PortOut_ex_1/main.cpp)
 
 ## Related content
 

--- a/docs/api/memory/MemoryPool.md
+++ b/docs/api/memory/MemoryPool.md
@@ -22,7 +22,7 @@ mpool.free(message);
 
 This example shows [Queue](queue.html) and MemoryPool managing measurements.
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/rtos_queue/)](https://os.mbed.com/teams/mbed_example/code/rtos_queue/file/bbbae4aa4768/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/Queue/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/Queue/main.cpp)
 
 ## Related content
 

--- a/docs/api/networkinterfaces/EthInterface.md
+++ b/docs/api/networkinterfaces/EthInterface.md
@@ -55,7 +55,7 @@ Network interface `connect` failure causes:
 
 Here is an example of an HTTP client program. The program brings up Ethernet as the underlying network interface and uses it to perform an HTTP transaction over a TCPSocket:
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/TCPSocket_Example/)](https://os.mbed.com/teams/mbed_example/code/TCPSocket_Example/file/50f1485931f1/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_NetworkSocket/TCPSocket/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_NetworkSocket/TCPSocket/main.cpp)
 
 ## Related content
 

--- a/docs/api/rtos/events_tutorial.md
+++ b/docs/api/rtos/events_tutorial.md
@@ -34,7 +34,7 @@ Note that though this document assumes the presence of a single event loop in th
 
 Once you start the event loop, it can post events. Let's consider an example of a program that attaches two interrupt handlers for an InterruptIn object, using the InterruptIn `rise` and `fall` functions. The `rise` handler will run in interrupt context, and the `fall` handler will run in user context (more specifically, in the context of the event loop's thread). The full code for the example can be found below:
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/events_ex_1/)](https://os.mbed.com/teams/mbed_example/code/events_ex_1/file/69c11c7877b6/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_1/main.cpp)
 
 The above code executes two handler functions (`rise_handler` and `fall_handler`) in two different contexts:
 

--- a/docs/api/storage/QSPIFBlockDevice.md
+++ b/docs/api/storage/QSPIFBlockDevice.md
@@ -15,4 +15,4 @@ For more information about the SFDP JEDEC standard, please see [its documentatio
 
 This example creates a QSPIFBlockDevice, erases a sector, programs it, reads the block back and cleans up.
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/QSPIFBlockDevice_example/)](https://os.mbed.com/teams/mbed_example/code/QSPIFBlockDevice_example/file/5608693b47aa/main.cpp/)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Storage/QSPIFBlockDevice_ex_1/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_Storage/QSPIFBlockDevice_ex_1/main.cpp)


### PR DESCRIPTION
more example snippets have been moved from teamsite to Github.
This PR update the links to them:

the PR that move the code over is :
https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/110