### PR TITLE
Minor Chrono updates

### DIFF
--- a/docs/api/io/Timer.md
+++ b/docs/api/io/Timer.md
@@ -2,14 +2,14 @@
 
 <span class="images">![](../../images/classmbed_1_1_timer.png)<span>Timer class hierarchy</span></span>
 
-Use the Timer interface to create, start, stop and read a timer for measuring precise times (better than millisecond precision).
+Use the Timer interface to create, start, stop and read a stopwatch-like timer for measuring precise times (better than millisecond precision).
 
 You can independently create, start and stop any number of Timer objects.
 
 ## Warnings and notes
 
-- Timers are based on 64-bit unsigned microsecond counters, but for backward compatibility, the `read_ms()` and `read_us()` methods only return 32-bit signed integers. This limits their range before wrapping to 49 days and 35 minutes respectively. Use `read_high_resolution_us()` to access the full range of over 500,000 years.
-- While a Timer is running, deep sleep is blocked to maintain accurate timing. If you don't need microsecond precision, consider using the LowPowerTimer class instead because this does not block deep sleep mode.
+- Timers are based on 64-bit signed microsecond counters, giving a range of over 250,000 years.
+- While a Timer is running, deep sleep is blocked to maintain accurate timing. If you don't need microsecond precision, consider using the LowPowerTimer or Kernel::Clock classes instead because these do not block deep sleep mode.
 
 ## Timer class reference
 

--- a/docs/api/rtos/Kernel.md
+++ b/docs/api/rtos/Kernel.md
@@ -6,9 +6,9 @@ The Kernel namespace implements interfaces to attach a function to some kernel e
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/development/mbed-os-api-doxy/namespacertos_1_1_kernel.html)
 
-## get_ms_count() example
+## Kernel::Clock example
 
-The function `get_ms_count()` can be used to read the current RTOS kernel millisecond tick count. The below code snippet demonstrates use of the `get_ms_count()` function to calculate the elapsed time:
+The nested class `Clock` can be used to read the current RTOS kernel millisecond tick count as a C++11 Chrono time point. The below code snippet demonstrates use of `Kernel::Clock` to calculate the elapsed time:
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/Kernel_get_ms_count)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/Kernel_get_ms_count/main.cpp)
 

--- a/docs/contributing/guidelines/style.md
+++ b/docs/contributing/guidelines/style.md
@@ -152,9 +152,10 @@ Occasionally, namespaces are used to act as-if "static singleton" objects. One e
 Below is an example of typical namespace use in a source file:
 
 ```
-    using namespace rtos;
+    using namespace rtos; // for ThisThread
+    using namespace std::chrono_literals; // for 1s
 
-    ThisThread::sleep_for(1000);
+    ThisThread::sleep_for(1s);
 
 ```
 


### PR DESCRIPTION
Some minor updates corresponding to https://github.com/ARMmbed/mbed-os/pull/12425

Bulk of updates are in examples: https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/112

A more significant section on Chrono should follow, based on the design document in the code PR, but these are the minimum to stop examples using deprecated APIs.