### PR TITLE
bare metal API table: Nordic Cordio BLE now supported

### DIFF
--- a/docs/bare_metal/bare_metal.md
+++ b/docs/bare_metal/bare_metal.md
@@ -74,7 +74,7 @@ For a breakdown of supported APIs, please see [the full API list](../apis/index.
         </tr>
         <tr>
             <td>BLE</td>
-            <td>&#10004; (can be manually enabled)<br>Except `COMPONENT_BlueNRG_MS` and `TARGET_NORDIC_CORDIO`</td>
+            <td>&#10004; (can be manually enabled)<br>Except `COMPONENT_BlueNRG_MS`</td>
         </tr>    
         <tr>
             <td>NFC</td>

--- a/docs/bare_metal/bare_metal.md
+++ b/docs/bare_metal/bare_metal.md
@@ -74,7 +74,7 @@ For a breakdown of supported APIs, please see [the full API list](../apis/index.
         </tr>
         <tr>
             <td>BLE</td>
-            <td>&#10004; (can be manually enabled)<br>Except `COMPONENT_BlueNRG_MS`</td>
+            <td>&#10004; (can be manually enabled)<br>Except BlueNRG-MS component</td>
         </tr>    
         <tr>
             <td>NFC</td>

--- a/docs/bare_metal/bare_metal.md
+++ b/docs/bare_metal/bare_metal.md
@@ -74,7 +74,7 @@ For a breakdown of supported APIs, please see [the full API list](../apis/index.
         </tr>
         <tr>
             <td>BLE</td>
-            <td>&#10004; (can be manually enabled)<br>Except BlueNRG-MS component</td>
+            <td>&#10004; (can be manually enabled)<br>Except the BlueNRG-MS component</td>
         </tr>    
         <tr>
             <td>NFC</td>


### PR DESCRIPTION
`TARGET_NORDIC_CORDIO` is now supported following https://github.com/ARMmbed/mbed-os/pull/12956. Also change `COMPONENT_BlueNRG_MS` -> `BlueNRG-MS component` for readability.