### PR TITLE
(Preceding snippet PR) Improved explanation of Wait/Ticker/Timeout/Threads/EventQueue

### DIFF
--- a/docs/api/platform/flow_control.md
+++ b/docs/api/platform/flow_control.md
@@ -11,9 +11,9 @@ If we want to automatically blink an LED, we have four main techniques:
 1. [Thread](#thread)
 1. [EventQueue](#eventqueue)
 
-All above techniques accomplish delays but cater to different requirements for precision, efficiency and context.
+The techniques cater to different requirements for precision, efficiency and context.
 
-<span class="tips">**Tip:** You may want to read the [power optimization](../apis/platform-concepts.html) tutorial to understand how to achieve power savings. </span>
+<span class="tips">**Tip:** You may want to read the [power optimization](../apis/platform-concepts.html) tutorial to learn how to save power. </span>
 
 ### Busy wait
 
@@ -21,13 +21,13 @@ Busy wait is a method that blocks the processor for a period of time. The proces
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Busy-Wait)](https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Busy-Wait/blob/v6.0/main.cpp)
 
-Notice `wait_us()` - it is part of the [Wait API](../mbed-os-api-doxy/group__platform__wait__api.html) to busy wait a given number of microseconds.
+Notice `wait_us()` - it is part of the [Wait API](../mbed-os-api-doxy/group__platform__wait__api.html), and sets the busy wait time as number of microseconds.
 
 The Wait API is an ISR-safe way to create short delays of nanoseconds to a few microseconds. However, we do not recommend busy waiting for longer delays.
 
-The following techniques are better suited for milliseconds to seconds delays which apply to our example's use case.
+For longer delays - millisecond to seconds - use one of the other techniques. 
 
-### Ticker, Timeout
+### Ticker and Timeout
 
 Tickers and Timeouts are non-blocking, interrupt-based ways of creating a time interval - your code continues to execute or sleep when there is nothing to do. The difference is that Tickers are recurring whereas Timeouts are one-off.
 
@@ -39,30 +39,29 @@ Here is an example that uses a ticker object:
 
 If you don't need the precision of a high-frequency ticker or timeout, we recommend that you use LowPowerTicker or LowPowerTimeout instead. These allow the system to be put in deep sleep mode.
 
-- _High-resolution microsecond ticker/timeout_ ([Ticker](ticker.html), [Timeout](timeout.html))
-- _Low Power ticker/timeout_ ([LowPowerTicker](lowpowerticker.html), [LowPowerTimeout](lowpowertimeout.html))
+- High-resolution microsecond [Ticker](../apis/ticker.html) and [timeout](../apis/timeout.html). 
+- [Low Power Ticker](../apis/lowpowerticker.html) and [Low Power Timeout](../apis/lowpowertimeout.html).
 
-Usage of the low power classes will inform the operating system of your desire to allow Deep Sleep mode on your system, although actually entering deep sleep depends on the specific environment and characteristics of your system. For more information about Sleep and Deep Sleep, please refer to our [documentation page](power-management-sleep.html) as well as watch our [Mbed Office Hours video](https://www.youtube.com/watch?v=OFfOlBaegdg&t=12s) where the concepts of Sleep and Deep Sleep are described in-depth.
+Use the the low power classes to inform the operating system you want to allow deep sleep mode on your system. Note that entering deep sleep depends on the specific environment and characteristics of your system, not just your API selection. For more information about sleep and deep sleep, please refer to our [documentation about power management](../apis/power-management-sleep.html) and our [Mbed Office Hours video](https://www.youtube.com/watch?v=OFfOlBaegdg&t=12s).
 
 ### Thread
 
-If your application is running in RTOS mode then [Thread](../apis/thread.html)s are another efficient way to blink an LED. During the waiting period, it is possible to take advantage of Mbed OS optimizations to automatically conserve power and deal with other tasks.
+If your application is running in RTOS mode then [Threads](../apis/thread.html) are another efficient way to blink an LED. During the waiting period, it is possible to take advantage of Mbed OS optimizations to automatically conserve power and deal with other tasks. This makes Threads the most efficient way to run tasks in Mbed OS.
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Thread)](https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Thread/blob/v6.0/main.cpp)
 
-Threads are the most efficient ways to run tasks in Mbed OS since the operating system internally contains optimizations for efficient scheduling of tasks and maximizing the system's sleep time.
 
 ### EventQueue
 
-The [EventQueue](../apis/eventqueue.html) class has a simple-to-use `call_every()` function to schedule repeated actions:
+The [EventQueue](../apis/eventqueue.html) class uses the `call_every()` function to schedule repeated actions:
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue/main.cpp)
 
-<span class="tips">**Tip:** For one-off delays, use `call_in()`.
+For one-off delays, use `call_in()`.
 
-Just as with Ticker/Timeout, if no threads are running during a wait, the system enters sleep mode.</span>
+Just as with Ticker and Timeout, if no threads are running during a wait, the system enters sleep mode.
 
-A major advantage of EventQueue over [Ticker/Timeout](#ticker-timeout) is that the handler is called in the same context (thread, in the case of RTOS) where the EventQueue is dispatched, thus ISR-related restrictions (e.g. no `printf`, no `Muxex` usage, etc.) do not apply.
+A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so ISR-related restrictions (such as no `printf` oand no `Muxex`) do not apply.
 
 ## Flow control for manual actions
 

--- a/docs/api/platform/flow_control.md
+++ b/docs/api/platform/flow_control.md
@@ -17,11 +17,11 @@ The techniques cater to different requirements for precision, efficiency and con
 
 The Wait API creates delays by actively blocking the execution for a period of time. It uses the busy wait strategy - internally running a loop until the end of the period.
 
-Here is an example that uses `wait_us()` of the API to wait a number of microseconds:
+Here is an example that uses the API's `wait_us()` function to wait a number of microseconds:
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Busy-Wait)](https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Busy-Wait/blob/v6.0/main.cpp)
 
-The processor is active for the entire duration, so the Wait API is suitable when you need short delays (nanoseconds to a few microseconds) without triggering [sleep modes](../apis/power-management-sleep.html) which have some wake-up latencies. It is also safe to use in interrupt contexts. However, we do not recommend busy waiting for longer delays, during which the system may not be able to switch to other tasks or save power as it cannot sleep.
+The processor is active for the entire duration, so the Wait API is suitable when you need short delays (nanoseconds to a few microseconds) without triggering [sleep modes](../apis/power-management-sleep.html), which have some wake-up latencies. It is also safe to use in interrupt contexts. However, we do not recommend busy waiting for longer delays: the system may not be able to switch to other tasks or save power by sleeping.
 
 For longer delays - millisecond to seconds - use one of the other techniques. 
 
@@ -39,7 +39,7 @@ If you don't need the precision of a high-frequency Ticker or Timeout, we recomm
 
 ### Thread
 
-If your application is running in RTOS mode then [Threads](../apis/thread.html) are another efficient way to blink an LED. During the waiting period, it is possible to take advantage of Mbed OS optimizations to automatically conserve power and deal with other tasks. This makes Threads the most efficient way to run tasks in Mbed OS.
+If your application is running in RTOS mode then [Threads](../apis/thread.html) are another efficient way to blink an LED. During the waiting period, Mbed OS automatically conserves power and deals with other tasks. This makes Threads the most efficient way to run tasks in Mbed OS.
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Thread)](https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Thread/blob/v6.0/main.cpp)
 
@@ -50,7 +50,7 @@ The [EventQueue](../apis/eventqueue.html) class uses the `call_every()` function
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue/main.cpp)
 
-For one-off delays, use `call_in()`. Just as with Ticker and Timeout, if no threads are running during a wait, the system enters [sleep or deep sleep mode](../apis/power-management-sleep.html). A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so interrupt-related restrictions (such as no `printf` oand no `Mutex`) do not apply.
+For one-off delays, use `call_in()`. Just as with Ticker and Timeout, if no threads are running during a wait, the system enters [sleep or deep sleep mode](../apis/power-management-sleep.html). A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so interrupt-related restrictions (such as no `printf` and no `Mutex`) do not apply.
 
 ## Handling user actions
 

--- a/docs/api/platform/flow_control.md
+++ b/docs/api/platform/flow_control.md
@@ -1,19 +1,17 @@
 # Application flow control
 
-We can use Blinky to explore flow control and task management in Arm Mbed OS applications. We'll look at automated actions first, then move on to handling user actions.
+We can use Blinky to explore flow control and task management in Arm Mbed OS applications. We'll look at automating actions with delays first, then move on to handling user actions.
 
-## Flow control for delayed actions
+## Automating actions with delays
 
 If we want to automatically blink an LED, we have four main techniques:
 
 1. [Busy wait](#busy-wait)
-1. [Ticker, Timeout](#ticker-timeout)
+1. [Ticker and Timeout](#ticker-and-timeout)
 1. [Thread](#thread)
 1. [EventQueue](#eventqueue)
 
 The techniques cater to different requirements for precision, efficiency and context.
-
-<span class="tips">**Tip:** You may want to read the [power optimization](../apis/platform-concepts.html) tutorial to learn how to save power. </span>
 
 ### Busy wait
 
@@ -29,7 +27,7 @@ For longer delays - millisecond to seconds - use one of the other techniques.
 
 ### Ticker and Timeout
 
-Tickers and Timeouts are non-blocking, interrupt-based ways of creating a time interval - your code continues to execute or sleep when there is nothing to do. The difference is that Tickers are recurring whereas Timeouts are one-off.
+[Tickers](../apis/ticker.html) and [Timeouts](../apis/timeout.html) are non-blocking, interrupt-based ways of creating a time interval - your code continues to execute or sleep when there is nothing to do. The difference is that Tickers are recurring whereas Timeouts are one-off.
 
 Here is an example that uses a ticker object:
 
@@ -37,12 +35,7 @@ Here is an example that uses a ticker object:
 
 <span class="warnings"> **Warning:** A ticker/timeout's handlers are executed in ISR context and thus, like any ISR handlers, should return quickly and not use `printf` or APIs that are not intended for ISRs.</span>
 
-If you don't need the precision of a high-frequency ticker or timeout, we recommend that you use LowPowerTicker or LowPowerTimeout instead. These allow the system to be put in deep sleep mode.
-
-- High-resolution microsecond [Ticker](../apis/ticker.html) and [timeout](../apis/timeout.html). 
-- [Low Power Ticker](../apis/lowpowerticker.html) and [Low Power Timeout](../apis/lowpowertimeout.html).
-
-Use the the low power classes to inform the operating system you want to allow deep sleep mode on your system. Note that entering deep sleep depends on the specific environment and characteristics of your system, not just your API selection. For more information about sleep and deep sleep, please refer to our [documentation about power management](../apis/power-management-sleep.html) and our [Mbed Office Hours video](https://www.youtube.com/watch?v=OFfOlBaegdg&t=12s).
+If you don't need the precision of a high-frequency Ticker or Timeout, we recommend that you use [LowPowerTicker](../apis/lowpowerticker.html) or [Low Power Timeout](../apis/lowpowertimeout.html) instead. The low power classes inform the operating system you want to allow deep sleep mode on your system. Note that entering deep sleep also depends on the specific environment and characteristics of your system, not just your API selection. For more information about sleep and deep sleep, please refer to our [documentation about power management](../apis/power-management-sleep.html) and our [Mbed Office Hours video](https://www.youtube.com/watch?v=OFfOlBaegdg&t=12s).
 
 ### Thread
 
@@ -57,13 +50,9 @@ The [EventQueue](../apis/eventqueue.html) class uses the `call_every()` function
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue/main.cpp)
 
-For one-off delays, use `call_in()`.
+For one-off delays, use `call_in()`. Just as with Ticker and Timeout, if no threads are running during a wait, the system enters [sleep or deep sleep mode](../apis/power-management-sleep.html). A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so ISR-related restrictions (such as no `printf` oand no `Mutex`) do not apply.
 
-Just as with Ticker and Timeout, if no threads are running during a wait, the system enters sleep mode.
-
-A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so ISR-related restrictions (such as no `printf` oand no `Muxex`) do not apply.
-
-## Flow control for manual actions
+## Handling user actions
 
 Let’s use a DigitalIn pin from the button to control the application. There are two ways to read input data: we can either constantly poll the button, or set an interrupt to trigger when pressed. We’ll explore these methods below.
 
@@ -86,3 +75,7 @@ An alternative way to poll the button is to use an interrupt. Interrupts let you
 In the code above a heartbeat function runs on LED2, which lets you see that your code is running. Then we connect an InterruptIn object to the button and set it so that when the button rises from 0 to 1, the toggle function is called; the function toggles LED1. This way the application can turn the LED on and off as needed, without needing to “waste” time waiting or actively polling an inactive button. The MCU is free to move on to other things .
 
 Interrupt driven programming is one of the fundamental paradigms of microcontroller programming.
+
+## Further reading
+
+- [Power optimization](../apis/platform-concepts.html)

--- a/docs/api/platform/flow_control.md
+++ b/docs/api/platform/flow_control.md
@@ -33,7 +33,7 @@ Here is an example that uses a ticker object:
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Ticker)](https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Ticker/blob/v6.0/main.cpp)
 
-<span class="warnings"> **Warning:** A ticker/timeout's handlers are executed in ISR context and thus, like any ISR handlers, should return quickly and not use `printf` or APIs that are not intended for ISRs.</span>
+<span class="warnings"> **Warning:** A ticker/timeout's handlers are executed in interrupt contexts and thus, like any interrupt handlers, should return quickly and not use `printf` or APIs that are not intended for interrupts.</span>
 
 If you don't need the precision of a high-frequency Ticker or Timeout, we recommend that you use [LowPowerTicker](../apis/lowpowerticker.html) or [Low Power Timeout](../apis/lowpowertimeout.html) instead. The low power classes inform the operating system you want to allow deep sleep mode on your system. Note that entering deep sleep also depends on the specific environment and characteristics of your system, not just your API selection. For more information about sleep and deep sleep, please refer to our [documentation about power management](../apis/power-management-sleep.html) and our [Mbed Office Hours video](https://www.youtube.com/watch?v=OFfOlBaegdg&t=12s).
 
@@ -50,7 +50,7 @@ The [EventQueue](../apis/eventqueue.html) class uses the `call_every()` function
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/Tutorials_UsingAPIs/Flow-Control-EventQueue/main.cpp)
 
-For one-off delays, use `call_in()`. Just as with Ticker and Timeout, if no threads are running during a wait, the system enters [sleep or deep sleep mode](../apis/power-management-sleep.html). A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so ISR-related restrictions (such as no `printf` oand no `Mutex`) do not apply.
+For one-off delays, use `call_in()`. Just as with Ticker and Timeout, if no threads are running during a wait, the system enters [sleep or deep sleep mode](../apis/power-management-sleep.html). A major advantage of EventQueue over Ticker and Timeout is that the handler is called in the same context as the EventQueue is dispatched (thread, in the case of RTOS), so interrupt-related restrictions (such as no `printf` oand no `Mutex`) do not apply.
 
 ## Handling user actions
 

--- a/docs/api/platform/flow_control.md
+++ b/docs/api/platform/flow_control.md
@@ -6,22 +6,22 @@ We can use Blinky to explore flow control and task management in Arm Mbed OS app
 
 If we want to automatically blink an LED, we have four main techniques:
 
-1. [Busy wait](#busy-wait)
+1. [Wait API](#wait-api)
 1. [Ticker and Timeout](#ticker-and-timeout)
 1. [Thread](#thread)
 1. [EventQueue](#eventqueue)
 
 The techniques cater to different requirements for precision, efficiency and context.
 
-### Busy wait
+### Wait API
 
-Busy wait is a method that blocks the processor for a period of time. The processor runs at full power for the duration of the wait:
+The Wait API creates delays by actively blocking the execution for a period of time. It uses the busy wait strategy - internally running a loop until the end of the period.
+
+Here is an example that uses `wait_us()` of the API to wait a number of microseconds:
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Busy-Wait)](https://github.com/ARMmbed/mbed-os-snippet-Flow-Control-Busy-Wait/blob/v6.0/main.cpp)
 
-Notice `wait_us()` - it is part of the [Wait API](../mbed-os-api-doxy/group__platform__wait__api.html), and sets the busy wait time as number of microseconds.
-
-The Wait API is an ISR-safe way to create short delays of nanoseconds to a few microseconds. However, we do not recommend busy waiting for longer delays.
+The processor is active for the entire duration, so the Wait API is suitable when you need short delays (nanoseconds to a few microseconds) without triggering [sleep modes](../apis/power-management-sleep.html) which have some wake-up latencies. It is also safe to use in interrupt contexts. However, we do not recommend busy waiting for longer delays, during which the system may not be able to switch to other tasks or save power as it cannot sleep.
 
 For longer delays - millisecond to seconds - use one of the other techniques. 
 


### PR DESCRIPTION
DEPENDS ON https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/115

This work is initially intended to borrow part of #1216 to [Application flow control](https://os.mbed.com/docs/mbed-os/v6.0-preview/tutorials/application-flow-control.html) - credits to @cvasilak. Some of the explanations around Ticker and Thread are taken from there.

Additionally, this PR adds some missing information:
* The _value_ of busy wait is that it's suitable for short, high-precision delays - existing docs only focus on its energy penalty.
* Ticker is recurring, Timeout is one-off. And they are non-blocking waits.
* EventQueue can create delays _on its own_.