### PR TITLE
(Preceding snippet PR) Bare metal applications with microlib should not return from main()

### DIFF
--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -24,18 +24,18 @@ This links your application with `microlib` for the `ARM` toolchain and `newlib-
 
 ### Non-returning main() required
 
-Exiting from `main()` is not supported by [Arm microlib](#arm-microlib) and causes a bare metal application to crash. Here we show two ways to prevent this.
+Arm microlib doesn't support exiting from `main()`; attempting to exit from `main()` causes a bare metal application to crash. Here we show two ways to prevent this.
 
 #### Sleep in a loop
 
-One recommended technique is sleep in a loop at the end of `main()`:
+One recommended technique is to sleep in a loop at the end of `main()`:
 ```
 while (true) {
     sleep();
 }
 ```
 
-This is energy-efficient compared to an empty `while (true) {}` loop which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
+This is energy-efficient compared to an empty `while (true) {}` loop, which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
 
 #### Dispatching an EventQueue
 

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -66,7 +66,7 @@ After you have completed the steps above, add `small` to the `supported_c_libs` 
 
 ### Non-returning main()
 
-Arm microlib doesn't support exiting from `main()`; attempting to exit from `main()` causes a bare metal application to crash. Here we show two ways to prevent this.
+Arm microlib doesn't support returning from `main()`; attempting to return from `main()` causes a bare metal application to crash. Here we show two ways to prevent this.
 
 #### Sleeping in a loop
 

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -89,4 +89,4 @@ The call to `queue.dispatch_forever()` never returns, as long as we don't break 
 
 ### Note on uARM toolchain
 
-The uARM toolchain is the ARMC6 toolchain with the Arm microlib, the C micro-library. This toolchain will be deprecated after 5.15.
+The uARM toolchain is the ARMC5 toolchain with the Arm microlib, the C micro-library. This toolchain will be deprecated after 5.15.

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -22,7 +22,7 @@ You can build with the smaller C libraries by creating an `mbed_app.json` with t
 
 This links your application with `microlib` for the `ARM` toolchain and `newlib-nano` for the `GCC_ARM` toolchain.
 
-<span class="notes">**Note:** You bare-metal application should _not_ return from `main()` if it uses Arm `microlib`. Please see [Non-returning main()](#non-returning-main) for advice.</span>
+<span class="notes">**Note:** If your application uses the Arm microlib, it should not return from `main()`. Please see [non-returning main() below](#non-returning-main) for advice.</span>
 
 ## Newlib-nano
 
@@ -77,7 +77,7 @@ while (true) {
 }
 ```
 
-This is energy-efficient compared to an empty `while (true) {}` loop, which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
+This is energy efficient compared to an empty `while (true) {}` loop, which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
 
 #### Dispatching an EventQueue
 
@@ -85,7 +85,7 @@ If your application is based on an `EventQueue`, dispatching it at the end of `m
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
 
-The call to `queue.dispatch_forever()` never returns, as long as we don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
+The call to `queue.dispatch_forever()` never returns, as long as you don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
 
 ### Note on uARM toolchain
 

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -89,4 +89,4 @@ The call to `queue.dispatch_forever()` never returns, as long as you don't break
 
 ### Note on uARM toolchain
 
-The uARM toolchain is the ARMC5 toolchain with the Arm microlib, the C micro-library. This toolchain will be deprecated after 5.15.
+The uARM toolchain is the ARMC6 toolchain with the Arm microlib, the C micro-library. This toolchain will be deprecated after 5.15.

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -29,7 +29,7 @@ Exiting from `main()` is not supported by [Arm microlib](#arm-microlib) and caus
 #### Sleep in a loop
 
 One recommended technique is sleep in a loop at the end of `main()`:
-```C
+```
 while (true) {
     sleep();
 }

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -22,6 +22,29 @@ You can build with the smaller C libraries by creating an `mbed_app.json` with t
 
 This links your application with `microlib` for the `ARM` toolchain and `newlib-nano` for the `GCC_ARM` toolchain.
 
+### Non-returning main() required
+
+Exiting from `main()` is not supported by [Arm microlib](#arm-microlib) and causes a bare metal application to crash. Here we show two ways to prevent this.
+
+#### Sleep in a loop
+
+One recommended technique is sleep in a loop at the end of `main()`:
+```C
+while (true) {
+    sleep();
+}
+```
+
+This is energy-efficient compared to an empty `while (true) {}` loop which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
+
+#### Dispatching an EventQueue
+
+If your application is based on an `EventQueue`, dispatching it at the end of `main()` works as well:
+
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
+
+The call to `queue.dispatch()` never returns, as long as we don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
+
 ## Newlib-nano
 
 [Newlib-nano](https://community.arm.com/developer/ip-products/system/b/embedded-blog/posts/shrink-your-mcu-code-size-with-gcc-arm-embedded-4-7) is an open source C library targeting embedded microcontrollers. It is based on newlib but is much smaller. One restriction is that newlib-nano is not thread-safe, so an application that uses the RTOS should not use it.

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -22,28 +22,7 @@ You can build with the smaller C libraries by creating an `mbed_app.json` with t
 
 This links your application with `microlib` for the `ARM` toolchain and `newlib-nano` for the `GCC_ARM` toolchain.
 
-### Non-returning main() required
-
-Arm microlib doesn't support exiting from `main()`; attempting to exit from `main()` causes a bare metal application to crash. Here we show two ways to prevent this.
-
-#### Sleep in a loop
-
-One recommended technique is to sleep in a loop at the end of `main()`:
-```
-while (true) {
-    sleep();
-}
-```
-
-This is energy-efficient compared to an empty `while (true) {}` loop, which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
-
-#### Dispatching an EventQueue
-
-If your application is based on an `EventQueue`, dispatching it at the end of `main()` works as well:
-
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
-
-The call to `queue.dispatch_forever()` never returns, as long as we don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
+<span class="notes">**Note:** You bare-metal application should _not_ return from `main()` if it uses Arm `microlib`. Please see [Non-returning main()](#non-returning-main) for advice.</span>
 
 ## Newlib-nano
 
@@ -84,6 +63,29 @@ After you have completed the steps above, add `small` to the `supported_c_libs` 
     "iar": ["std"]
 }
 ```
+
+### Non-returning main()
+
+Arm microlib doesn't support exiting from `main()`; attempting to exit from `main()` causes a bare metal application to crash. Here we show two ways to prevent this.
+
+#### Sleeping in a loop
+
+One recommended technique is to sleep in a loop at the end of `main()`:
+```
+while (true) {
+    sleep();
+}
+```
+
+This is energy-efficient compared to an empty `while (true) {}` loop, which keeps the processor running. A loop is still needed, because `sleep()` returns after the system is woken up by an interrupt.
+
+#### Dispatching an EventQueue
+
+If your application is based on an `EventQueue`, dispatching it at the end of `main()` works as well:
+
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
+
+The call to `queue.dispatch_forever()` never returns, as long as we don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
 
 ### Note on uARM toolchain
 

--- a/docs/bare_metal/c_small_libs.md
+++ b/docs/bare_metal/c_small_libs.md
@@ -43,7 +43,7 @@ If your application is based on an `EventQueue`, dispatching it at the end of `m
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
 
-The call to `queue.dispatch()` never returns, as long as we don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
+The call to `queue.dispatch_forever()` never returns, as long as we don't break the dispatch anywhere. The `EventQueue` class puts the system to sleep to save energy between events.
 
 ## Newlib-nano
 

--- a/docs/bare_metal/using_bare_metal.md
+++ b/docs/bare_metal/using_bare_metal.md
@@ -9,7 +9,7 @@ Here is a code snippet that can work for both Mbed OS profiles; it prints text a
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
 
-<span class="notes">**Note:** To be compatible with Arm microlib, a bare metal application should not return from `main()`. In this example the `queue.dispatch_forever()` call never returns. For more details, see [Non-returning main() required](../baremetal/using-small-c-libraries.html#non-returning-main-required).</span>
+<span class="notes">**Note:** To be compatible with Arm microlib, a bare metal application should not return from `main()`. In this example, the `queue.dispatch_forever()` call never returns. For more details, see [Non-returning main()](../baremetal/using-small-c-libraries.html#non-returning-main).</span>
 
 ## 1. Creating a bare metal application
 

--- a/docs/bare_metal/using_bare_metal.md
+++ b/docs/bare_metal/using_bare_metal.md
@@ -9,7 +9,7 @@ Here is a code snippet that can work for both Mbed OS profiles; it prints text a
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
 
-<span class="notes">**Note:** To be compatible with Arm microlib, a bare metal application should not return from `main()`. In this example the `queue.dispatch()` call never returns. For more details, see [Non-returning main() required](../baremetal/using-small-c-libraries.html#non-returning-main-required).</span>
+<span class="notes">**Note:** To be compatible with Arm microlib, a bare metal application should not return from `main()`. In this example the `queue.dispatch_forever()` call never returns. For more details, see [Non-returning main() required](../baremetal/using-small-c-libraries.html#non-returning-main-required).</span>
 
 ## 1. Creating a bare metal application
 

--- a/docs/bare_metal/using_bare_metal.md
+++ b/docs/bare_metal/using_bare_metal.md
@@ -9,6 +9,8 @@ Here is a code snippet that can work for both Mbed OS profiles; it prints text a
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/)](https://github.com/ARMmbed/mbed-os-examples-docs_only/blob/master/APIs_RTOS/EventQueue_ex_2/main.cpp)
 
+<span class="notes">**Note:** To be compatible with Arm microlib, a bare metal application should not return from `main()`. In this example the `queue.dispatch()` call never returns. For more details, see [Non-returning main() required](../baremetal/using-small-c-libraries.html#non-returning-main-required).</span>
+
 ## 1. Creating a bare metal application
 
 To create the application:


### PR DESCRIPTION
REQUIRES https://github.com/ARMmbed/mbed-os-examples-docs_only/pull/116

Arm microlib cannot handle exit from `main()`: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0475f/BAJHEGCE.html

This is not an issue in the RTOS mode in which the main thread is one of the several threads created on boot. But a bare-metal application needs to explicitly avoid returning from `main()`. This PR documents this fact and suggests ways around it. 

Even though it affects microlib only, I added the advice to the generic section which is easier to notice. And an application should in principle be compatible with any configurations.