### PR TITLE
Bare metal tutorial: do not label/syntax-check partial JSON excerpt

### DIFF
--- a/docs/bare_metal/using_bare_metal.md
+++ b/docs/bare_metal/using_bare_metal.md
@@ -54,7 +54,7 @@ This example depends on the `EventQueue` class, so you need to add the library t
 
     For example: `mbed-os/events/mbed_lib.json`:
 
-    ```json
+    ```
     {
         "name": "events",
         "config": {


### PR DESCRIPTION
This should fix the syntax check failure.