### PR TITLE
Update library configuration pages

### DIFF
--- a/docs/reference/configuration/ble-config.md
+++ b/docs/reference/configuration/ble-config.md
@@ -39,89 +39,78 @@ These are feature that you can disable:
 ```
 Configuration parameters
 ------------------------
-
-Name: ble.ble-role-observer
-    Description: Include observer BLE role support (scanning for and processing advertising packets).
+Name: ble.ble-feature-extended-advertising
+    Description: Include extended advertising support (advertising sets, secondary channels).
     Defined by: library:ble
-    Value: true
-    Macro name: BLE_ROLE_OBSERVER
-
-Name: ble.ble-role-broadcaster
-    Description: Include broadcaster BLE role support (sending advertising packets).
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_ROLE_BROADCASTER
-
-Name: ble.ble-role-central
-    Description: Include central BLE role support (initiates connections), depends on observer role.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_ROLE_CENTRAL
-
-Name: ble.ble-role-peripheral
-    Description: Include peripheral BLE role support (accepts connections), depends on broadcaster role.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_ROLE_PERIPHERAL
-
+    Macro name: BLE_FEATURE_EXTENDED_ADVERTISING
+    Value: 1 (set by library:ble)
 Name: ble.ble-feature-gatt-client
     Description: Include Gatt Client BLE role support (requests remote operations on attributes), depends on peripheral and central role.
     Defined by: library:ble
-    Value: true
     Macro name: BLE_FEATURE_GATT_CLIENT
-
+    Value: 1 (set by library:ble)
 Name: ble.ble-feature-gatt-server
     Description: Include Gatt Server BLE role support (executes operations on stored attributes), depends on peripheral or central role.
     Defined by: library:ble
-    Value: true
     Macro name: BLE_FEATURE_GATT_SERVER
-
-Name: ble.ble-feature-security
-    Description: Include security support (key management), depends on peripheral or central role.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_SECURITY
-
-Name: ble.ble-feature-secure-connections
-    Description: Include secure connections support, depends on the security feature.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_SECURE_CONNECTIONS
-
-Name: ble.ble-feature-signing
-    Description: Include signing support (signed attribute writes), depends on the security feature.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_SIGNING
-
-Name: ble.ble-feature-whitelist
-    Description: Include whitelist support (peer filtering), depends on the security feature.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_WHITELIST
-
-Name: ble.ble-feature-privacy
-    Description: Include privacy support(random resolvable addresses), depends on the security feature.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_PRIVACY
-
-Name: ble.ble-feature-phy-management
-    Description: Additional PHY support (2M and Coded)
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_PHY_MANAGEMENT
-
-Name: ble.ble-feature-extended-advertising
-    Description: Include extended advertising support(advertising sets, secondary channels), depends on the phy management feature.
-    Defined by: library:ble
-    Value: true
-    Macro name: BLE_FEATURE_EXTENDED_ADVERTISING
-
+    Value: 1 (set by library:ble)
 Name: ble.ble-feature-periodic-advertising
     Description: Include periodic advertising support, depends on the extended advertising feature.
     Defined by: library:ble
-    Value: true
     Macro name: BLE_FEATURE_PERIODIC_ADVERTISING
-
+    Value: 1 (set by library:ble)
+Name: ble.ble-feature-phy-management
+    Description: Additional PHY support (2M and Coded)
+    Defined by: library:ble
+    Macro name: BLE_FEATURE_PHY_MANAGEMENT
+    Value: 1 (set by library:ble)
+Name: ble.ble-feature-privacy
+    Description: Include privacy support (random resolvable addresses), depends on the security feature.
+    Defined by: library:ble
+    Macro name: BLE_FEATURE_PRIVACY
+    Value: 1 (set by library:ble)
+Name: ble.ble-feature-secure-connections
+    Description: Include secure connections support, depends on the security feature.
+    Defined by: library:ble
+    Macro name: BLE_FEATURE_SECURE_CONNECTIONS
+    Value: 1 (set by library:ble)
+Name: ble.ble-feature-security
+    Description: Include security support (key management), depends on peripheral or central role.
+    Defined by: library:ble
+    Macro name: BLE_FEATURE_SECURITY
+    Value: 1 (set by library:ble)
+Name: ble.ble-feature-signing
+    Description: Include signing support (signed attribute writes), depends on the security feature.
+    Defined by: library:ble
+    Macro name: BLE_FEATURE_SIGNING
+    Value: 1 (set by library:ble)
+Name: ble.ble-feature-whitelist
+    Description: Include whitelist support (peer filtering), depends on the security feature.
+    Defined by: library:ble
+    Macro name: BLE_FEATURE_WHITELIST
+    Value: 1 (set by library:ble)
+Name: ble.ble-role-broadcaster
+    Description: Include broadcaster BLE role support (sending advertising packets).
+    Defined by: library:ble
+    Macro name: BLE_ROLE_BROADCASTER
+    Value: 1 (set by library:ble)
+Name: ble.ble-role-central
+    Description: Include central BLE role support (initiates connections), depends on observer role.
+    Defined by: library:ble
+    Macro name: BLE_ROLE_CENTRAL
+    Value: 1 (set by library:ble)
+Name: ble.ble-role-observer
+    Description: Include observer BLE role support (scanning for and processing advertising packets).
+    Defined by: library:ble
+    Macro name: BLE_ROLE_OBSERVER
+    Value: 1 (set by library:ble)
+Name: ble.ble-role-peripheral
+    Description: Include peripheral BLE role support (accepts connections), depends on broadcaster role.
+    Defined by: library:ble
+    Macro name: BLE_ROLE_PERIPHERAL
+    Value: 1 (set by library:ble)
+Name: ble.present
+    Defined by: library:ble
+    Macro name: MBED_CONF_BLE_PRESENT
+    Value: 1 (set by library:ble)
 ```

--- a/docs/reference/configuration/connectivity-config.md
+++ b/docs/reference/configuration/connectivity-config.md
@@ -28,8 +28,13 @@ Name: lwip.default-thread-stacksize
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE
     Value: 512 (set by library:lwip)
+Name: lwip.dhcp-timeout
+    Description: DHCP timeout value
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_DHCP_TIMEOUT
+    Value: 60 (set by library:lwip)
 Name: lwip.enable-ppp-trace
-    Description: Enable trace support for PPP interfaces
+    Description: Enable trace support for PPP interfaces (obsolete: use netsocket/ppp configuration instead)
     Defined by: library:lwip
     No value set
 Name: lwip.ethernet-enabled
@@ -51,82 +56,129 @@ Name: lwip.ipv6-enabled
     Description: Enable IPv6
     Defined by: library:lwip
     No value set
-Name: lwip.mem-size
-    Description: Size of heap (bytes) - used for outgoing packets, and also used by some drivers for reception. Current default (used if null here) is set to 1600 in opt.h, unless overridden by target Ethernet drivers.
-    Defined by: library:lwip
-    Macro name: MBED_CONF_LWIP_MEM_SIZE
-    Value: 33270 (set by library:lwip[Freescale])
-Name: lwip.memp-num-tcp-seg
-    Description: Number of simultaneously queued TCP segments. Current default (used if null here) is set to 16 in opt.h, unless overridden by target Ethernet drivers.
+Name: lwip.l3ip-enabled
+    Description: Enable support for L3IP interfaces
     Defined by: library:lwip
     No value set
+Name: lwip.mbox-size
+    Description: mailbox size
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_MBOX_SIZE
+    Value: 8 (set by library:lwip)
+Name: lwip.mem-size
+    Description: Size of heap (bytes) - used for outgoing packets, and also used by some drivers for reception, see LWIP's opt.h for more information. Current default is 1600.
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_MEM_SIZE
+    Value: 2310 (set by library:lwip[STM])
+Name: lwip.memp-num-tcp-seg
+    Description: Number of simultaneously queued TCP segments, see LWIP opt.h for more information. Current default is 16.
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_MEMP_NUM_TCP_SEG
+    Value: 16 (set by library:lwip)
+Name: lwip.memp-num-tcpip-msg-inpkt
+    Description: Number of simultaneously queued TCP messages that are received
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_MEMP_NUM_TCPIP_MSG_INPKT
+    Value: 8 (set by library:lwip)
+Name: lwip.num-netbuf
+    Description: Number of netbufs, each netbuf requires 64 bytes of RAM, see LWIP's opt.h for more information. Current default is 8.
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_NUM_NETBUF
+    Value: 8 (set by library:lwip)
+Name: lwip.num-pbuf
+    Description: Number of non-pool pbufs, each needs 92 bytes of RAM, see LWIP's opt.h for more information. Current default is 8.
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_NUM_PBUF
+    Value: 8 (set by library:lwip)
 Name: lwip.pbuf-pool-bufsize
-    Description: Size of pbufs in pool. If set to null, lwIP will base the size on the TCP MSS, which is 536 unless overridden by the target
+    Description: Size of pbufs in pool, see LWIP's opt.h for more information.
     Defined by: library:lwip
     No value set
 Name: lwip.pbuf-pool-size
-    Description: Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.
+    Description: Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading, see LWIP's opt.h for more information. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default  is 5.
     Defined by: library:lwip
-    No value set
+    Macro name: MBED_CONF_LWIP_PBUF_POOL_SIZE
+    Value: 5 (set by library:lwip)
 Name: lwip.ppp-enabled
-    Description: Enable support for PPP interfaces
+    Description: Enable support for PPP interfaces (obsolete: use netsocket/ppp configuration instead)
     Defined by: library:lwip
     No value set
 Name: lwip.ppp-ipv4-enabled
-    Description: Enable support for ipv4 PPP interface
+    Description: Enable support for ipv4 PPP interface (obsolete: use netsocket/ppp configuration instead)
     Defined by: library:lwip
-    Macro name: NSAPI_PPP_IPV4_AVAILABLE
-    Value: 1 (set by library:lwip)
+    No value set
 Name: lwip.ppp-ipv6-enabled
-    Description: Enable support for ipv6 PPP interface
+    Description: Enable support for ipv6 PPP interface (obsolete: use netsocket/ppp configuration instead)
     Defined by: library:lwip
     No value set
 Name: lwip.ppp-thread-stacksize
-    Description: Thread stack size for PPP
+    Description: Thread stack size for PPP (obsolete: use netsocket/ppp configuration instead)
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_PPP_THREAD_STACKSIZE
     Value: 768 (set by library:lwip)
+Name: lwip.present
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_PRESENT
+    Value: 1 (set by library:lwip)
+Name: lwip.raw-socket-enabled
+    Description: Enable lwip raw sockets, required for Mbed OS ICMPSocket
+    Defined by: library:lwip
+    No value set
 Name: lwip.socket-max
-    Description: Maximum number of open TCPServer, TCPSocket and UDPSocket instances allowed, including one used internally for DNS.  Each requires 236 bytes of pre-allocated RAM
+    Description: Maximum number of open TCPSocket and UDPSocket instances allowed, including one used internally for DNS.  Each requires 236 bytes of pre-allocated RAM
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_SOCKET_MAX
     Value: 4 (set by library:lwip)
+Name: lwip.tcp-close-timeout
+    Description: Maximum timeout (ms) for TCP close handshaking timeout
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_TCP_CLOSE_TIMEOUT
+    Value: 1000 (set by library:lwip)
 Name: lwip.tcp-enabled
     Description: Enable TCP
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_TCP_ENABLED
     Value: 1 (set by library:lwip)
 Name: lwip.tcp-maxrtx
-    Description: Maximum number of retransmissions of data segments.
+    Description: Maximum number of retransmissions of data segments, see LWIP's opt.h for more information. Current default is 6.
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_TCP_MAXRTX
     Value: 6 (set by library:lwip)
 Name: lwip.tcp-mss
-    Description: TCP Maximum segment size. Current default (used if null here) is set to 536 in opt.h, unless overridden by target Ethernet drivers.
+    Description: TCP Maximum segment size, see LWIP opt.h for more information. Current default is 536.
     Defined by: library:lwip
-    No value set
+    Macro name: MBED_CONF_LWIP_TCP_MSS
+    Value: 536 (set by library:lwip)
 Name: lwip.tcp-server-max
-    Description: Maximum number of open TCPServer instances allowed.  Each requires 72 bytes of pre-allocated RAM
+    Description: Maximum number of open TCP server instances allowed.  Each requires 72 bytes of pre-allocated RAM
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_TCP_SERVER_MAX
     Value: 4 (set by library:lwip)
 Name: lwip.tcp-snd-buf
-    Description: TCP sender buffer space (bytes). Current default (used if null here) is set to (2 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.
+    Description: TCP sender buffer space (bytes), see LWIP's opt.h for more information. Current default is (2 * TCP_MSS).
     Defined by: library:lwip
-    No value set
+    Macro name: MBED_CONF_LWIP_TCP_SND_BUF
+    Value: (2 * TCP_MSS) (set by library:lwip)
 Name: lwip.tcp-socket-max
     Description: Maximum number of open TCPSocket instances allowed.  Each requires 196 bytes of pre-allocated RAM
     Defined by: library:lwip
     Macro name: MBED_CONF_LWIP_TCP_SOCKET_MAX
     Value: 4 (set by library:lwip)
 Name: lwip.tcp-synmaxrtx
-    Description: Maximum number of retransmissions of SYN segments. Current default (used if null here) is set to 6 in opt.h
+    Description: Maximum number of retransmissions of SYN segments, see LWIP's opt.h for more information. Current default is 6.
     Defined by: library:lwip
-    No value set
+    Macro name: MBED_CONF_LWIP_TCP_SYNMAXRTX
+    Value: 6 (set by library:lwip)
 Name: lwip.tcp-wnd
-    Description: TCP sender buffer space (bytes). Current default (used if null here) is set to (4 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.
+    Description: TCP sender buffer space (bytes), see LWIP's opt.h for more information. Current default is (4 * TCP_MSS).
     Defined by: library:lwip
-    No value set
+    Macro name: MBED_CONF_LWIP_TCP_WND
+    Value: (4 * TCP_MSS) (set by library:lwip)
+Name: lwip.tcpip-thread-priority
+    Description: Priority of lwip TCPIP thread
+    Defined by: library:lwip
+    Macro name: MBED_CONF_LWIP_TCPIP_THREAD_PRIORITY
+    Value: osPriorityNormal (set by library:lwip)
 Name: lwip.tcpip-thread-stacksize
     Description: Stack size for lwip TCPIP thread
     Defined by: library:lwip
@@ -171,11 +223,25 @@ Select the default interface type by using one of the following `target.network-
 ```
 Configuration parameters
 ------------------------
+Name: target.app_offset
+    Description: Application start offset in ROM
+    Defined by: target:Target
+    No value set
 Name: target.boot-stack-size
     Description: Define the boot stack size in bytes. This value must be a multiple of 8
     Defined by: target:Target
     Macro name: MBED_CONF_TARGET_BOOT_STACK_SIZE
     Value: 0x400 (set by library:rtos[*])
+Name: target.clock_source
+    Description: Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI
+    Defined by: target:DISCO_L475VG_IOT01A
+    Macro name: CLOCK_SOURCE
+    Value: USE_PLL_MSI (set by target:DISCO_L475VG_IOT01A)
+Name: target.console-uart
+    Description: Target has UART console on pins STDIO_UART_TX, STDIO_UART_RX. Value is only significant if target has SERIAL device.
+    Defined by: target:Target
+    Macro name: MBED_CONF_TARGET_CONSOLE_UART
+    Value: 1 (set by target:Target)
 Name: target.console-uart-flow-control
     Description: Console hardware flow control. Options: null, RTS, CTS, RTSCTS.
     Defined by: target:Target
@@ -183,7 +249,45 @@ Name: target.console-uart-flow-control
 Name: target.deep-sleep-latency
     Description: Time in ms required to go to and wake up from deep sleep (max 10)
     Defined by: target:Target
+    Macro name: MBED_CONF_TARGET_DEEP_SLEEP_LATENCY
+    Value: 4 (set by target:MCU_STM32)
+Name: target.default-form-factor
+    Description: Default form factor of this board taken from supported_form_factors. This must be a lowercase string such as 'arduino'
+    Defined by: target:Target
     No value set
+Name: target.header_offset
+    Description: Application header offset in ROM
+    Defined by: target:Target
+    No value set
+Name: target.init-us-ticker-at-boot
+    Description: Initialize the microsecond ticker at boot rather than on first use, and leave it initialized. This speeds up wait_us in particular.
+    Defined by: target:Target
+    Macro name: MBED_CONF_TARGET_INIT_US_TICKER_AT_BOOT
+    Value: 1 (set by target:MCU_STM32)
+Name: target.lpticker_delay_ticks
+    Description: https://os.mbed.com/docs/latest/porting/low-power-ticker.html
+    Defined by: target:MCU_STM32
+    No value set
+Name: target.lpticker_lptim
+    Description: This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer
+    Defined by: target:DISCO_L475VG_IOT01A
+    Macro name: MBED_CONF_TARGET_LPTICKER_LPTIM
+    Value: 1 (set by target:DISCO_L475VG_IOT01A)
+Name: target.lpticker_lptim_clock
+    Description: Default value for LPTIM clock (lpticker_lptim == 1). Value is the dividing factor. Choose 1, 2 or 4
+    Defined by: target:MCU_STM32
+    Macro name: MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK
+    Value: 1 (set by target:MCU_STM32)
+Name: target.lpuart_clock_source
+    Description: Define the LPUART clock source. Mask values: USE_LPUART_CLK_LSE, USE_LPUART_CLK_PCLK1, USE_LPUART_CLK_HSI
+    Defined by: target:MCU_STM32
+    Macro name: MBED_CONF_TARGET_LPUART_CLOCK_SOURCE
+    Value: USE_LPUART_CLK_LSE|USE_LPUART_CLK_PCLK1 (set by target:MCU_STM32)
+Name: target.lse_available
+    Description: Define if a Low Speed External xtal (LSE) is available on the board (0 = No, 1 = Yes). If Yes, the LSE will be used to clock the RTC, LPUART, ... otherwise the Low Speed Internal clock (LSI) will be used
+    Defined by: target:MCU_STM32
+    Macro name: MBED_CONF_TARGET_LSE_AVAILABLE
+    Value: 1 (set by target:MCU_STM32)
 Name: target.mpu-rom-end
     Description: Last address of ROM protected by the MPU
     Defined by: target:Target
@@ -192,47 +296,76 @@ Name: target.mpu-rom-end
 Name: target.network-default-interface-type
     Description: Default network interface type. Typical options: null, ETHERNET, WIFI, CELLULAR, MESH
     Defined by: target:Target
-    Macro name: MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE
-    Value: ETHERNET (set by target:K64F)
+    No value set
+Name: target.stdio_uart_rx
+    Description: default RX STDIO pins is defined in PinNames.h file, but it can be overridden
+    Defined by: target:MCU_STM32
+    No value set
+Name: target.stdio_uart_tx
+    Description: default TX STDIO pins is defined in PinNames.h file, but it can be overridden
+    Defined by: target:MCU_STM32
+    No value set
+Name: target.tickless-from-us-ticker
+    Description: Run tickless from the microsecond ticker rather than the low power ticker. Running tickless off of the microsecond ticker improves interrupt latency on targets which use lpticker_delay_ticks
+    Defined by: target:Target
+    No value set
+Name: target.xip-enable
+    Description: Enable Execute In Place (XIP) on this target. Value is only significant if the board has executable external storage such as QSPIF. If this is enabled, customize the linker file to choose what text segments are placed on external storage
+    Defined by: target:Target
+    No value set
 ```
 
 ```
 Configuration parameters
 ------------------------
 Name: nsapi.default-cellular-apn
+    Description: Default cellular Access Point Name.
     Defined by: library:nsapi
     No value set
 Name: nsapi.default-cellular-password
+    Description: Password for the default cellular network.
     Defined by: library:nsapi
     No value set
 Name: nsapi.default-cellular-plmn
+    Description: Default Public Land Mobile Network for cellular connection.
     Defined by: library:nsapi
     No value set
 Name: nsapi.default-cellular-sim-pin
+    Description: PIN for the default SIM card.
     Defined by: library:nsapi
     No value set
 Name: nsapi.default-cellular-username
+    Description: Username for the default cellular network.
     Defined by: library:nsapi
     No value set
 Name: nsapi.default-mesh-type
-    Description: Configuration type for MeshInterface::get_default_instance(). [LOWPAN/WISUN]
+    Description: Configuration type for MeshInterface::get_default_instance(). [LOWPAN/THREAD/WISUN]
     Defined by: library:nsapi
     Macro name: MBED_CONF_NSAPI_DEFAULT_MESH_TYPE
-    Value: LOWPAN (set by library:nsapi)
+    Value: THREAD (set by library:nsapi)
 Name: nsapi.default-stack
+    Description: Default stack to be used, valid values: LWIP, NANOSTACK.
     Defined by: library:nsapi
     Macro name: MBED_CONF_NSAPI_DEFAULT_STACK
     Value: LWIP (set by library:nsapi)
 Name: nsapi.default-wifi-password
+    Description: Password for the default Wi-Fi network.
     Defined by: library:nsapi
     No value set
 Name: nsapi.default-wifi-security
+    Description: Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2.
     Defined by: library:nsapi
     Macro name: MBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY
     Value: NONE (set by library:nsapi)
 Name: nsapi.default-wifi-ssid
+    Description: Default Wi-Fi SSID.
     Defined by: library:nsapi
     No value set
+Name: nsapi.dns-addresses-limit
+    Description: Max number IP addresses returned by  multiple DNS query
+    Defined by: library:nsapi
+    Macro name: MBED_CONF_NSAPI_DNS_ADDRESSES_LIMIT
+    Value: 10 (set by library:nsapi)
 Name: nsapi.dns-cache-size
     Description: Number of cached host name resolutions
     Defined by: library:nsapi
@@ -242,21 +375,26 @@ Name: nsapi.dns-response-wait-time
     Description: How long the DNS translator waits for a reply from a server in milliseconds
     Defined by: library:nsapi
     Macro name: MBED_CONF_NSAPI_DNS_RESPONSE_WAIT_TIME
-    Value: 5000 (set by library:nsapi)
+    Value: 10000 (set by library:nsapi)
 Name: nsapi.dns-retries
     Description: Number of DNS query retries that the DNS translator makes per server, before moving on to the next server. Total retries/attempts is always limited by dns-total-attempts.
     Defined by: library:nsapi
-    No value set
+    Macro name: MBED_CONF_NSAPI_DNS_RETRIES
+    Value: 1 (set by library:nsapi)
 Name: nsapi.dns-total-attempts
     Description: Number of total DNS query attempts that the DNS translator makes
     Defined by: library:nsapi
     Macro name: MBED_CONF_NSAPI_DNS_TOTAL_ATTEMPTS
-    Value: 3 (set by library:nsapi)
+    Value: 10 (set by library:nsapi)
+Name: nsapi.offload-tlssocket
+    Description: Use external TLSSocket implementation. Used network stack must support external TLSSocket setsockopt values (see nsapi_types.h)
+    Defined by: library:nsapi
+    No value set
 Name: nsapi.present
     Defined by: library:nsapi
     Macro name: MBED_CONF_NSAPI_PRESENT
     Value: 1 (set by library:nsapi)
-Name: nsapi.socket-stats-enable
+Name: nsapi.socket-stats-enabled
     Description: Enable network socket statistics
     Defined by: library:nsapi
     No value set

--- a/docs/reference/configuration/io-config.md
+++ b/docs/reference/configuration/io-config.md
@@ -8,6 +8,45 @@ This is the complete list of I/O configuration parameters. To view all configura
 ```
 Configuration parameters
 ------------------------
+Name: drivers.crc-table-size
+    Description: Number of entries in each of MbedCRC's pre-computed software tables. Higher values increase speed, but also increase image size. The value has no effect if the target performs the CRC in hardware. Permitted values are 0, 16 or 256.
+    Defined by: library:drivers
+    Macro name: MBED_CRC_TABLE_SIZE
+    Value: 16 (set by library:drivers)
+Name: drivers.qspi_csn
+    Description: QSPI chip select pin
+    Defined by: library:drivers
+    Macro name: MBED_CONF_DRIVERS_QSPI_CSN
+    Value: QSPI_FLASH1_CSN (set by library:drivers)
+Name: drivers.qspi_io0
+    Description: QSPI data I/O 0 pin
+    Defined by: library:drivers
+    Macro name: MBED_CONF_DRIVERS_QSPI_IO0
+    Value: QSPI_FLASH1_IO0 (set by library:drivers)
+Name: drivers.qspi_io1
+    Description: QSPI data I/O 1 pin
+    Defined by: library:drivers
+    Macro name: MBED_CONF_DRIVERS_QSPI_IO1
+    Value: QSPI_FLASH1_IO1 (set by library:drivers)
+Name: drivers.qspi_io2
+    Description: QSPI data I/O 2 pin
+    Defined by: library:drivers
+    Macro name: MBED_CONF_DRIVERS_QSPI_IO2
+    Value: QSPI_FLASH1_IO2 (set by library:drivers)
+Name: drivers.qspi_io3
+    Description: QSPI data I/O 3 pin
+    Defined by: library:drivers
+    Macro name: MBED_CONF_DRIVERS_QSPI_IO3
+    Value: QSPI_FLASH1_IO3 (set by library:drivers)
+Name: drivers.qspi_sck
+    Description: QSPI clock pin
+    Defined by: library:drivers
+    Macro name: MBED_CONF_DRIVERS_QSPI_SCK
+    Value: QSPI_FLASH1_SCK (set by library:drivers)
+Name: drivers.spi_count_max
+    Description: The maximum number of SPI peripherals used at the same time. Determines RAM allocated for SPI peripheral management. If null, limit determined by hardware.
+    Defined by: library:drivers
+    No value set
 Name: drivers.uart-serial-rxbuf-size
     Description: Default RX buffer size for a BufferedSerial instance (unit Bytes))
     Defined by: library:drivers

--- a/docs/reference/configuration/mesh-config.md
+++ b/docs/reference/configuration/mesh-config.md
@@ -92,6 +92,33 @@ Name: nanostack-eventloop.use_platform_tick_timer
     No value set
 ```
 ```
+Configuration parameters
+------------------------
+Name: nanostack-eventloop.exclude_highres_timer
+    Description: Exclude high resolution timer from build
+    Defined by: library:nanostack-eventloop
+    No value set
+Name: nanostack-eventloop.use_platform_tick_timer
+    Description: Use platform provided low resolution tick timer for eventloop
+    Defined by: library:nanostack-eventloop
+    No value set
+Name: nanostack-hal.critical-section-usable-from-interrupt
+    Description: Make critical section API usable from interrupt context. Else a mutex is used as locking primitive. Consult arm_hal_interrupt.c for possible side effects on interrupt latency.
+    Defined by: library:nanostack-hal
+    No value set
+Name: nanostack-hal.event-loop-dispatch-from-application
+    Description: Application is responsible of message dispatch loop. Else launch a separate thread for event-loop.
+    Defined by: library:nanostack-hal
+    No value set
+Name: nanostack-hal.event-loop-use-mbed-events
+    Description: Use Mbed OS global event queue for Nanostack event loop, rather than our own thread.
+    Defined by: library:nanostack-hal
+    No value set
+Name: nanostack-hal.event_loop_thread_stack_size
+    Description: Define event-loop thread stack size. [bytes]
+    Defined by: library:nanostack-hal
+    Macro name: MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_THREAD_STACK_SIZE
+    Value: 6144 (set by library:nanostack-hal)
 Name: nanostack.configuration
     Description: Build time configuration. Refer to Handbook for valid values. Default: full stack
     Defined by: library:nanostack
@@ -99,6 +126,8 @@ Name: nanostack.configuration
     Value: nanostack_full (set by library:nanostack)
 ```
 ```
+Configuration parameters
+------------------------
 Name: nanostack-hal.critical-section-usable-from-interrupt
     Description: Make critical section API usable from interrupt context. Else a mutex is used as locking primitive. Consult arm_hal_interrupt.c for possible side effects on interrupt latency.
     Defined by: library:nanostack-hal
@@ -126,7 +155,7 @@ This configuration allows you to adjust Nanostack's heap usage:
 Configuration parameters
 ------------------------
 Name: mbed-mesh-api.heap-size
-    Description: Nanostack's heap size [bytes: 0-‭4294967295‬]
+    Description: Nanostack's heap size [bytes: 0-4294967295]
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_HEAP_SIZE
     Value: 32500 (set by library:mbed-mesh-api)
@@ -205,55 +234,62 @@ The following parameters are only valid for the Wi-SUN FAN mesh network. These a
 Configuration parameters
 ------------------------
 Name: mbed-mesh-api.wisun-bc-channel-function
-    Description: Broadcast channel function.
+    Description: Broadcast channel function as specified in the Wi-SUN FAN specification. Wi-SUN stack will select channel function if value 255 is used.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_BC_CHANNEL_FUNCTION
     Value: 255 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-bc-dwell-interval
-    Description: Broadcast dwell interval. Range: 15-255 milliseconds
+    Description: Broadcast dwell interval. Range: 15-255 milliseconds. Wi-SUN stack default value will be used when set to 0.
     Defined by: library:mbed-mesh-api
     No value set
 Name: mbed-mesh-api.wisun-bc-fixed-channel
-    Description: Default fixed channel
+    Description: Default 16-bit fixed channel for multicast. Used when channel hopping is not desired.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_BC_FIXED_CHANNEL
-    Value: 0xffff (set by library:mbed-mesh-api)
+    Value: 65535 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-bc-interval
-    Description: Broadcast interval. Duration between broadcast dwell intervals. Range: 0-16777216 milliseconds
+    Description: 32-bit broadcast interval. Duration between broadcast dwell intervals. Wi-SUN stack default value will be used when set to 0.
     Defined by: library:mbed-mesh-api
     No value set
+Name: mbed-mesh-api.wisun-device-type
+    Description: Supported device operating modes: MESH_DEVICE_TYPE_WISUN_ROUTER, MESH_DEVICE_TYPE_WISUN_BORDER_ROUTER
+    Defined by: library:mbed-mesh-api
+    Macro name: MBED_CONF_MBED_MESH_API_WISUN_DEVICE_TYPE
+    Value: MESH_DEVICE_TYPE_WISUN_ROUTER (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-network-name
-    Description: default network name for wisun network
+    Description: Network name for a wisun network. Maximum network name length can be 32 ASCII characters excluding terminating 0
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_NETWORK_NAME
     Value: "Wi-SUN Network" (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-operating-class
-    Description: Operating class.
+    Description: Operating class for the regulatory-domain as specified in the Wi-SUN PHY Specification. Wi-SUN stack uses operating-class suitable for EU-region if value 255 is used.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_OPERATING_CLASS
     Value: 255 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-operating-mode
-    Description: Operating mode.
+    Description: Operating mode as specified in the Wi-SUN PHY Specification. Wi-SUN stack uses operating-mode suitable for EU-region if value 255 is used.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_OPERATING_MODE
     Value: 255 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-regulatory-domain
-    Description: Regulator domain.
+    Description: Regulator domain value as specified in the Wi-SUN PHY Specification. Default value 3 is for EU region.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_REGULATORY_DOMAIN
     Value: 3 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-uc-channel-function
-    Description: Unicast channel function.
+    Description: Unicast channel function as specified in the Wi-SUN FAN specification. Wi-SUN stack will select channel function if value 255 is used.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_UC_CHANNEL_FUNCTION
     Value: 255 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-uc-dwell-interval
-    Description: Unicast dwell interval. Range: 15-255 milliseconds
+    Description: Unicast dwell interval. Range: 15-255 milliseconds.
     Defined by: library:mbed-mesh-api
-    No value set
+    Macro name: MBED_CONF_MBED_MESH_API_WISUN_UC_DWELL_INTERVAL
+    Value: 255 (set by library:mbed-mesh-api)
 Name: mbed-mesh-api.wisun-uc-fixed-channel
-    Description: Default fixed channel
+    Description: Default 16-bit fixed channel for unicast. Used when channel hopping is not desired.
     Defined by: library:mbed-mesh-api
     Macro name: MBED_CONF_MBED_MESH_API_WISUN_UC_FIXED_CHANNEL
-    Value: 0xffff (set by library:mbed-mesh-api)
+    Value: 65535 (set by library:mbed-mesh-api)
+
 ```

--- a/docs/reference/configuration/platform-config.md
+++ b/docs/reference/configuration/platform-config.md
@@ -11,6 +11,15 @@ Name: platform.all-stats-enabled
     Description: Set to 1 to enable all platform stats. When enabled the functions mbed_stats_*_get returns non-zero data. See mbed_stats.h for more information
     Defined by: library:platform
     No value set
+Name: platform.callback-comparable
+    Description: Enables support for comparing two Callbacks. See notes on operator== for limitations. Can be disabled to save ROM if not required.
+    Defined by: library:platform
+    Macro name: MBED_CONF_PLATFORM_CALLBACK_COMPARABLE
+    Value: 1 (set by library:platform)
+Name: platform.callback-nontrivial
+    Description: Enables support for non-trivial callable objects in Callback. Can be disabled to save ROM if no-one is using non-trivial types. Changing this value may cause incompatibility with pre-built binaries.
+    Defined by: library:platform
+    No value set
 Name: platform.cpu-stats-enabled
     Description: Set to 1 to enable cpu stats. When enabled the function mbed_stats_cpu_get returns non-zero data. See mbed_stats.h for more information
     Defined by: library:platform
@@ -19,7 +28,7 @@ Name: platform.crash-capture-enabled
     Description: Enables crash context capture when the system enters a fatal error/crash.
     Defined by: library:platform
     Macro name: MBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED
-    Value: 1 (set by library:platform[K64F])
+    Value: 1 (set by library:platform[DISCO_L475VG_IOT01A])
 Name: platform.cthunk_count_max
     Description: The maximum CThunk objects used at the same time. This must be greater than 0 and less 256
     Defined by: library:platform
@@ -56,11 +65,7 @@ Name: platform.fatal-error-auto-reboot-enabled
     Description: Setting this to true enables auto-reboot on a fatal error.
     Defined by: library:platform
     Macro name: MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED
-    Value: 1 (set by library:platform[K64F])
-Name: platform.force-non-copyable-error
-    Description: Force compile time error when a NonCopyable object is copied
-    Defined by: library:platform
-    No value set
+    Value: 1 (set by library:platform[DISCO_L475VG_IOT01A])
 Name: platform.heap-stats-enabled
     Description: Set to 1 to enable heap stats. When enabled the function mbed_stats_heap_get returns non-zero data. See mbed_stats.h for more information
     Defined by: library:platform
@@ -75,16 +80,16 @@ Name: platform.memory-tracing-enabled
     Defined by: library:platform
     No value set
 Name: platform.minimal-printf-enable-64-bit
-    Description: Enable printing 64 bit integers when using mprintf profile
+    Description: Enable printing 64 bit integers when using minimal printf library
     Defined by: library:platform
     Macro name: MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_64_BIT
     Value: 1 (set by library:platform)
 Name: platform.minimal-printf-enable-floating-point
-    Description: Enable floating point printing when using mprintf profile
+    Description: Enable floating point printing when using minimal printf library
     Defined by: library:platform
     No value set
 Name: platform.minimal-printf-set-floating-point-max-decimals
-    Description: Maximum number of decimals to be printed
+    Description: Maximum number of decimals to be printed when using minimal printf library
     Defined by: library:platform
     Macro name: MBED_CONF_PLATFORM_MINIMAL_PRINTF_SET_FLOATING_POINT_MAX_DECIMALS
     Value: 6 (set by library:platform)
@@ -106,17 +111,19 @@ Name: platform.stdio-baud-rate
     Macro name: MBED_CONF_PLATFORM_STDIO_BAUD_RATE
     Value: 9600 (set by library:platform)
 Name: platform.stdio-buffered-serial
-    Description: (Applies if target.console-uart is true and stdio-minimal-console-only is false.) Use UARTSerial driver to obtain buffered serial I/O on stdin/stdout/stderr. If false, unbuffered serial_getc and serial_putc are used directly.
+    Description: (Applies if target.console-uart is true and stdio-minimal-console-only is false.) Use BufferedSerial driver to obtain buffered serial I/O on stdin/stdout/stderr. If false, unbuffered serial_getc and serial_putc are used directly.
     Defined by: library:platform
     No value set
 Name: platform.stdio-convert-newlines
     Description: Enable conversion to standard newlines on stdin/stdout/stderr
     Defined by: library:platform
-    No value set
+    Macro name: MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
+    Value: 1 (set by library:platform)
 Name: platform.stdio-convert-tty-newlines
     Description: Enable conversion to standard newlines on any tty FILE stream
     Defined by: library:platform
-    No value set
+    Macro name: MBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES
+    Value: 1 (set by library:platform)
 Name: platform.stdio-flush-at-exit
     Description: Enable or disable the flush of standard I/O's at exit.
     Defined by: library:platform

--- a/docs/reference/configuration/rtos-config.md
+++ b/docs/reference/configuration/rtos-config.md
@@ -16,13 +16,26 @@ This is the complete list of RTOS configuration parameters. To view all configur
 ```
 Configuration parameters
 ------------------------
+Name: rtos-api.present
+    Defined by: library:rtos-api
+    Macro name: MBED_CONF_RTOS_API_PRESENT
+    Value: 1 (set by library:rtos-api)
+Name: rtos.evflags-num
+    Description: Maximum number of CMSIS-RTOSv2 object-pool event flag objects that can be active at the same time
+    Defined by: library:rtos
+    No value set
 Name: rtos.idle-thread-stack-size
     Description: The size of the idle thread's stack
     Defined by: library:rtos
     Macro name: MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE
     Value: 512 (set by library:rtos)
+Name: rtos.idle-thread-stack-size-debug-extra
+    Description: Additional size to add to the idle thread when code compilation optimisation is disabled
+    Defined by: library:rtos
+    Macro name: MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE_DEBUG_EXTRA
+    Value: 128 (set by library:rtos[STM])
 Name: rtos.idle-thread-stack-size-tickless-extra
-    Description: Additional size to add to the idle thread when tickless is enabled and LPTICKER_DELAY_TICKS is used
+    Description: Additional size to add to the idle thread when a specific target or application implementation requires it or in case tickless is enabled and LPTICKER_DELAY_TICKS is used
     Defined by: library:rtos
     Macro name: MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE_TICKLESS_EXTRA
     Value: 256 (set by library:rtos)
@@ -31,15 +44,43 @@ Name: rtos.main-thread-stack-size
     Defined by: library:rtos
     Macro name: MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
     Value: 4096 (set by library:rtos)
+Name: rtos.msgqueue-data-size
+    Description: The total memory available for all CMSIS-RTOSv2 object-pool message queues combined
+    Defined by: library:rtos
+    No value set
+Name: rtos.msgqueue-num
+    Description: Maximum number of CMSIS-RTOSv2 object-pool message queues that can be active at the same time
+    Defined by: library:rtos
+    No value set
+Name: rtos.mutex-num
+    Description: Maximum number of CMSIS-RTOSv2 object-pool mutexes that can be active at the same time
+    Defined by: library:rtos
+    No value set
 Name: rtos.present
     Defined by: library:rtos
     Macro name: MBED_CONF_RTOS_PRESENT
     Value: 1 (set by library:rtos)
+Name: rtos.semaphore-num
+    Description: Maximum number of CMSIS-RTOSv2 object-pool semaphores that can be active at the same time
+    Defined by: library:rtos
+    No value set
+Name: rtos.thread-num
+    Description: Maximum number of CMSIS-RTOSv2 object-pool threads that can be active at the same time
+    Defined by: library:rtos
+    No value set
 Name: rtos.thread-stack-size
     Description: The default stack size of new threads
     Defined by: library:rtos
     Macro name: MBED_CONF_RTOS_THREAD_STACK_SIZE
     Value: 4096 (set by library:rtos)
+Name: rtos.thread-user-stack-size
+    Description: The total memory available for all CMSIS-RTOSv2 object-pool thread stacks combined
+    Defined by: library:rtos
+    No value set
+Name: rtos.timer-num
+    Description: Maximum number of CMSIS-RTOSv2 object-pool timers that can be active at the same time
+    Defined by: library:rtos
+    No value set
 Name: rtos.timer-thread-stack-size
     Description: The size of the timer thread's stack
     Defined by: library:rtos
@@ -64,7 +105,7 @@ Name: events.shared-eventsize
     Description: Event buffer size (bytes) for shared event queue
     Defined by: library:events
     Macro name: MBED_CONF_EVENTS_SHARED_EVENTSIZE
-    Value: 256 (set by library:events)
+    Value: 768 (set by library:events)
 Name: events.shared-highprio-eventsize
     Description: Event buffer size (bytes) for shared high-priority event queue
     Defined by: library:events

--- a/docs/reference/configuration/storage-config.md
+++ b/docs/reference/configuration/storage-config.md
@@ -365,6 +365,51 @@ Name: littlefs.read_size
     Defined by: library:littlefs
     Macro name: MBED_LFS_READ_SIZE
     Value: 64 (set by library:littlefs)
+Name: littlefs2.block_cycles
+    Description: Number of erase cycles before a block is forcefully evicted. Larger values are more efficient but cause less even wear distribution. 0 disables dynamic wear-leveling.
+    Defined by: library:littlefs2
+    Macro name: MBED_LFS2_BLOCK_CYCLES
+    Value: 1024 (set by library:littlefs2)
+Name: littlefs2.block_size
+    Description: Size of a logical block. This does not impact ram consumption and may be larger than the physical erase block. If the physical erase block is larger, littlefs will use that instead. Larger values will be faster but waste more storage when files are not aligned to a block size.
+    Defined by: library:littlefs2
+    Macro name: MBED_LFS2_BLOCK_SIZE
+    Value: 512 (set by library:littlefs2)
+Name: littlefs2.cache_size
+    Description: Size of read/program caches. Each file uses 1 cache, and littlefs allocates 2 caches for internal operations. Larger values should be faster but uses more RAM.
+    Defined by: library:littlefs2
+    Macro name: MBED_LFS2_CACHE_SIZE
+    Value: 64 (set by library:littlefs2)
+Name: littlefs2.enable_assert
+    Description: Enables asserts, true = enabled, false = disabled, null = disabled only in release builds
+    Defined by: library:littlefs2
+    No value set
+Name: littlefs2.enable_debug
+    Description: Enables debug logging, true = enabled, false = disabled, null = disabled only in release builds
+    Defined by: library:littlefs2
+    No value set
+Name: littlefs2.enable_error
+    Description: Enables error logging, true = enabled, false = disabled, null = disabled only in release builds
+    Defined by: library:littlefs2
+    No value set
+Name: littlefs2.enable_info
+    Description: Enables info logging, true = enabled, false = disabled, null = disabled only in release builds
+    Defined by: library:littlefs2
+    No value set
+Name: littlefs2.enable_warn
+    Description: Enables warn logging, true = enabled, false = disabled, null = disabled only in release builds
+    Defined by: library:littlefs2
+    No value set
+Name: littlefs2.intrinsics
+    Description: Enable intrinsics for bit operations such as ctz, popc, and le32 conversion. Can be disabled to help debug toolchain issues
+    Defined by: library:littlefs2
+    Macro name: MBED_LFS2_INTRINSICS
+    Value: 1 (set by library:littlefs2)
+Name: littlefs2.lookahead_size
+    Description: Size of the lookahead buffer. A larger lookahead reduces the allocation scans and results in a faster filesystem but uses more RAM.
+    Defined by: library:littlefs2
+    Macro name: MBED_LFS2_LOOKAHEAD_SIZE
+    Value: 64 (set by library:littlefs2)
 ```
 
 ## BlockDevice - default configuration


### PR DESCRIPTION
The configuration pages were updated using the script at `mbed-os-5-docs/check_tools/config-update.py`.

See usage below:

```
usage: config-update.py [-h] [-v] [path]

Copy mbed-os-5-docs (or make a symlink) to a mbed-os
repository. The script runs from mbed-os-5-docs/check_tools/ and iterates through
/path/to/mbed-
os-5-docs/check_tools/../docs/reference/configuration. You may pass a
directory or a file. In case of a directory, the script will run on all files
contained within it.

positional arguments:
  path           path to file or directory. (default:
                 /path/to/mbed-
                 os-5-docs/check_tools/../docs/reference/configuration)

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  increase verbosity of status information. (default: False)
```