### PR TITLE
Clarify guide requires Mbed CLI

### DIFF
--- a/docs/bare_metal/using_bare_metal.md
+++ b/docs/bare_metal/using_bare_metal.md
@@ -13,7 +13,7 @@ Here is a code snippet that can work for both Mbed OS profiles; it prints text a
 
 ## 1. Creating a bare metal application
 
-To create the application:
+To create the application using Mbed CLI:
 
 1. Create a new Mbed OS application and navigate to its directory:
 


### PR DESCRIPTION
The example at the top encourages developers to import it in the Online compiler (see button).

However, the tutorial below requires using Mbed CLI.
This is just a minor fix to clarify that.

@iriark01 