### PR TITLE
A serial driver should be installed on Windows 7 only

### DIFF
--- a/docs/api/connectivity/tutorials/intro-to-lora.md
+++ b/docs/api/connectivity/tutorials/intro-to-lora.md
@@ -304,7 +304,7 @@ Now you can verify whether the setup works by flashing this application to your 
     <span class="images">![](../../../images/lora10.png)<span>Compile button</span></span>
 
 1. When compilation succeeds, the compiler sends a file to your computer.
-1. Plug your development board into the computer (over micro-USB) to mount it as a USB mass storage device. In most cases, you do not need a driver, but you can find drivers [here](../program-setup/windows-serial-driver.html).
+1. Plug your development board into the computer (over micro-USB) to mount it as a USB mass storage device. If you are working on Windows 7, you might need to [install a serial driver](../program-setup/windows-serial-driver.html).
 1. Once the device mounts, drag the compiled file onto the board. This causes the device to boot. You can then see the device joining and then sending messages in the The Things Network console, under the **Data** tab:
 
     <span class="images">![](../../../images/ttn19.png)<span>We've got data!</span></span>

--- a/docs/api/connectivity/tutorials/intro-to-lora.md
+++ b/docs/api/connectivity/tutorials/intro-to-lora.md
@@ -304,7 +304,7 @@ Now you can verify whether the setup works by flashing this application to your 
     <span class="images">![](../../../images/lora10.png)<span>Compile button</span></span>
 
 1. When compilation succeeds, the compiler sends a file to your computer.
-1. Plug your development board into the computer (over micro-USB) to mount it as a USB mass storage device. If you are working on Windows 7, you might need to [install a serial driver](../program-setup/windows-serial-driver.html).
+1. Plug your development board into the computer (over micro-USB) to mount it as a USB mass storage device.
 1. Once the device mounts, drag the compiled file onto the board. This causes the device to boot. You can then see the device joining and then sending messages in the The Things Network console, under the **Data** tab:
 
     <span class="images">![](../../../images/ttn19.png)<span>We've got data!</span></span>

--- a/docs/api/drivers/uart/BufferedSerial.md
+++ b/docs/api/drivers/uart/BufferedSerial.md
@@ -52,7 +52,7 @@ You can view more information about the configurable settings and functions in t
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_buffered_serial.html)
 
-<span class="notes">**Note**: On a Windows machine, you need to install a USB serial driver. Please see the [Windows serial configuration](../program-setup/serial-communication.html#windows-serial-driver) document for more information.</span>
+<span class="notes">**Note**: On a Windows 7 machine, you need to install a USB serial driver. Please see the [Windows serial driver](../program-setup/serial-communication.html#windows-serial-driver) document for more information.</span>
 
 ## BufferedSerial examples
 

--- a/docs/api/drivers/uart/BufferedSerial.md
+++ b/docs/api/drivers/uart/BufferedSerial.md
@@ -52,8 +52,6 @@ You can view more information about the configurable settings and functions in t
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_buffered_serial.html)
 
-<span class="notes">**Note**: On a Windows 7 machine, you need to install a USB serial driver. Please see the [Windows serial driver](../program-setup/serial-communication.html#windows-serial-driver) document for more information.</span>
-
 ## BufferedSerial examples
 
 This example toggles an LED and echoes input to a terminal:

--- a/docs/api/drivers/uart/UnbufferedSerial.md
+++ b/docs/api/drivers/uart/UnbufferedSerial.md
@@ -14,7 +14,7 @@ You can view more information about the configurable settings and functions in t
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_unbuffered_serial.html)
 
-<span class="notes">**Note**: On a Windows machine, you need to install a USB serial driver. See [Windows serial configuration](../program-setup/serial-communication.html#windows-serial-driver).</span>
+<span class="notes">**Note**: On a Windows 7 machine, you need to install a USB serial driver. Please see the [Windows serial driver](../program-setup/serial-communication.html#windows-serial-driver) document for more information.</span>
 
 ## UnbufferedSerial Example
 

--- a/docs/api/drivers/uart/UnbufferedSerial.md
+++ b/docs/api/drivers/uart/UnbufferedSerial.md
@@ -14,8 +14,6 @@ You can view more information about the configurable settings and functions in t
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_unbuffered_serial.html)
 
-<span class="notes">**Note**: On a Windows 7 machine, you need to install a USB serial driver. Please see the [Windows serial driver](../program-setup/serial-communication.html#windows-serial-driver) document for more information.</span>
-
 ## UnbufferedSerial Example
 
 [![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-snippet-UnbufferedSerial/tree/v6.0)](https://github.com/ARMmbed/mbed-os-snippet-UnbufferedSerial/blob/v6.0/main.cpp)

--- a/docs/debugging-testing/debug/DAP.md
+++ b/docs/debugging-testing/debug/DAP.md
@@ -28,8 +28,6 @@ DAPLink debug probes appear on the host computer as a USB disk. Program files in
 The DAPLink debug probe also provides a USB serial port, which can be bridged through to a TTL UART on the target system.
 The USB serial port will appear on a Windows machine as a COM port, or on a Linux machine as a /dev/tty interface.
 
-If your operating system is Windows 7, please refer to the [Windows serial driver information](../program-setup/windows-serial-driver.html).
-
 ## Further reading
 
 - [DAPLink firmware updates and FAQ page](https://armmbed.github.io/DAPLink/).

--- a/docs/debugging-testing/debug/DAP.md
+++ b/docs/debugging-testing/debug/DAP.md
@@ -28,7 +28,7 @@ DAPLink debug probes appear on the host computer as a USB disk. Program files in
 The DAPLink debug probe also provides a USB serial port, which can be bridged through to a TTL UART on the target system.
 The USB serial port will appear on a Windows machine as a COM port, or on a Linux machine as a /dev/tty interface.
 
-For more information on configuring your host computer to use this feature, please the [Windows serial driver information](../program-setup/windows-serial-driver.html).
+If your operating system is Windows 7, please refer to the [Windows serial driver information](../program-setup/windows-serial-driver.html).
 
 ## Further reading
 

--- a/docs/introduction/tutorials_intro.md
+++ b/docs/introduction/tutorials_intro.md
@@ -22,7 +22,7 @@ This page is an index of all tutorials and official examples.
 
 These tutorials teach you to communicate with your development board, an essential part of programming and debugging:
 
-- [Windows serial driver tutorial](../program-setup/windows-serial-driver.html)
+- [Windows serial driver tutorial](../program-setup/windows-serial-driver.html) (Windows 7 only)
 - [Board to PC communication over USB tutorial](../program-setup/serial-communication.html)
 
 ## Debugging

--- a/docs/program-setup/serial/serial_communication.md
+++ b/docs/program-setup/serial/serial_communication.md
@@ -2,7 +2,7 @@
 
 The Arm Mbed microcontroller on your board can communicate with a host PC over the same USB cable that you use for programming.
 
-<span class="tips">If you're working on Windows earlier than Windows 10, you might need to [install a serial driver](../program-setup/windows-serial-driver.html).</span>
+<span class="tips">If you're working on Windows 7, you might need to [install a serial driver](../program-setup/windows-serial-driver.html).</span>
 
 This allows you to:
 

--- a/docs/program-setup/serial/serial_driver.md
+++ b/docs/program-setup/serial/serial_driver.md
@@ -1,8 +1,10 @@
 # Windows serial driver
 
+<span class="warnings">**Warning**: This page is for **Windows 7 only**. Do NOT install the serial driver on Windows 8 or above - serial ports work out of the box.</span>
+
 You can connect your board to your computer over USB. This works out of the box on Linux and macOS. If you are using Windows, you may need to install a serial port driver:
 
-1. Download the [Arm Mbed Windows serial port driver](http://os.mbed.com/media/downloads/drivers/mbedWinSerial_16466.exe).
+1. Download the [Arm Mbed Windows serial port driver](http://os.mbed.com/media/downloads/drivers/mbedWinSerial_16466.exe) (**Windows 7 only**).
 1. Plug in your Arm Mbed device over USB. It mounts as an Mbed drive.
 1. Close all Explorer windows showing the Mbed drive.
 1. Run the installer. This may take some time or display a few "unsigned driver" warnings.

--- a/docs/program-setup/serial/serial_driver.md
+++ b/docs/program-setup/serial/serial_driver.md
@@ -1,6 +1,6 @@
 # Windows serial driver
 
-<span class="warnings">**Warning**: This page is for **Windows 7 only**. Do NOT install the serial driver on Windows 8 or above - serial ports work out of the box.</span>
+<span class="warnings">**Warning**: This page is for **Windows 7 only**. Do not install the serial driver on Windows 8 or newer; serial ports work out of the box with these versions.</span>
 
 You can connect your board to your computer over USB. This works out of the box on Linux and macOS. If you are using Windows, you may need to install a serial port driver:
 


### PR DESCRIPTION
Fixes #1332 

This PR
* stresses on the serial driver doc page that it only applies to Windows 7
* update other docs that link to the serial driver doc page