### PR TITLE
Remove product ID requests

### DIFF
--- a/docs/porting/custom-target-porting.md
+++ b/docs/porting/custom-target-porting.md
@@ -243,8 +243,6 @@ There are more directory levels than target configuration levels because many ta
    mbedls --mock 0764:IMAGINARYBOARD
    ```
 
-  <span class="notes">**Note:** If you intend to release a new target to the Mbed community, it needs a unique Platform ID. To get one, please contact your technical account manager or email [our support team](mailto:support@mbed.com).</span>
-
 1. Run the tests, with the following command:
 
    ```


### PR DESCRIPTION
Note we explicitly want to avoid the need to assign a product/board ID for custom boards.
The intention is to help developers to build products that don't depend on an internal database.

Note we'll document the contribution process for Mbed Enabled board and that will include information on requests to board ID (more info IOTOSM-28).

@iriark01 