### PR TITLE
Update cli-reqs.md

### DIFF
--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -104,7 +104,7 @@ To install `mbed-cli` bash completion:
 
 1. Clone the Mbed CLI repository: `git clone https://github.com/ARMmbed/mbed-cli`.
 1. Navigate to the `mbed-cli/tools/bash_completion` directory.
-1. Copy the `mbed` script into the  `~/.bash_completion.d` directory (you may need to create this directory first, and if that is the case then you may also need to add a line like `source ~/.bash_completion.d/mbed` to `~/.bashrc`).
+1. Copy the `mbed` script into the  `~/.bash_completion.d` directory (you may need to create this directory first, and then you may also need to add a line, for example `source ~/.bash_completion.d/mbed` to `~/.bashrc`).
 1. Restart the terminal.
 
 ## Configuration options

--- a/docs/tools/CLI/cli-setup/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup/cli-reqs.md
@@ -104,7 +104,7 @@ To install `mbed-cli` bash completion:
 
 1. Clone the Mbed CLI repository: `git clone https://github.com/ARMmbed/mbed-cli`.
 1. Navigate to the `mbed-cli/tools/bash_completion` directory.
-1. Copy the `mbed` script into the  `~/.bash_completion.d` directory (you may need to create this directory first).
+1. Copy the `mbed` script into the  `~/.bash_completion.d` directory (you may need to create this directory first, and if that is the case then you may also need to add a line like `source ~/.bash_completion.d/mbed` to `~/.bashrc`).
 1. Restart the terminal.
 
 ## Configuration options


### PR DESCRIPTION
In short: existing instructions for adding bash completion for mbed-cli didn't quite work.

I found that in a fresh install of Linux Mint 20 Cinnamon, I did not have a folder `~/.bash_completion.d`, and after adding one as per the Bash completion instructions in the mbed-os docs (and copying over the `mbed` script), the terminal still did not have bash completion for the mbed command. 

I found that I needed to add an instruction somewhere to make the terminal actually source that `mbed` script, since there was not anything in place that was looking in `~/.bash_completion.d`.

The actual method I used was adding:
`
for file in ~/.bash_completion.d/* ; do
    source "$file"
done
`
to my `~/.bashrc` file.