### PR TITLE
Use python3 for travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Language and cache settings
 language: python
-python: 2.7
+python: 3.8
 cache:
   pip: true
   directories:


### PR DESCRIPTION
Upgrade Travis job to use Python 3.8 instead of Python 2.7.