### PR TITLE
Mbed TLS no longer has a development-psa branch

### DIFF
--- a/docs/porting/security/TLS-on-PSA.md
+++ b/docs/porting/security/TLS-on-PSA.md
@@ -4,7 +4,7 @@
 
 The version of Mbed TLS shipped in Mbed OS builds with PSA enabled by default. However, you can build a PSA-enabled version of Mbed TLS from [our Git repository](https://github.com/ARMmbed/mbedtls):
 
-1. Clone the repository, switch to the `development-psa` branch and initialize the submodule: `git checkout development-psa && git submodule update --init`.
+1. Clone the repository and switch to the `master` branch.
 1. Enable the `MBEDTLS_USE_PSA_CRYPTO` build-time configuration option in `include/mbedtls/config.h`, either by editing the file manually, or using the config script: `scripts/config.pl set MBEDTLS_USE_PSA_CRYPTO`.
 1. Build normally, for example (with GNU Make) make all test or (with CMake) `mkdir build && cd build && cmake .. && make all test`.
 

--- a/docs/porting/security/TLS-on-PSA.md
+++ b/docs/porting/security/TLS-on-PSA.md
@@ -49,7 +49,7 @@ This mainly involves using the API function `mbedtls_pk_setup_opaque()` to wrap 
 
 ### Application flow without PSA
 
-1. At application startup, make sure `mbedtls_platform_setup() is called if relevant.
+1. At application startup, make sure `mbedtls_platform_setup()` is called if relevant.
 1. Declare (and allocate) an object of type `mbedtls_pk_context`
 1. Load a key into that PK context, presumably using `mbedtls_pk_parse_key()`, or by generating a fresh key.
 1. Configure the pending CSR object to use that key by calling `mbedtls_x509write_csr_set_key()` on that PK context.

--- a/docs/porting/security/TLS-on-PSA.md
+++ b/docs/porting/security/TLS-on-PSA.md
@@ -6,7 +6,7 @@ The version of Mbed TLS shipped in Mbed OS builds with PSA enabled by default. H
 
 1. Clone the repository and switch to the `master` branch.
 1. Enable the `MBEDTLS_USE_PSA_CRYPTO` build-time configuration option in `include/mbedtls/config.h`, either by editing the file manually, or using the config script: `scripts/config.pl set MBEDTLS_USE_PSA_CRYPTO`.
-1. Build normally, for example (with GNU Make) make all test or (with CMake) `mkdir build && cd build && cmake .. && make all test`.
+1. Build normally, for example (with GNU Make) `make lib` or (with CMake) `mkdir build && cd build && cmake .. && make lib`.
 
 ## Using PSA-enabled Mbed TLS
 

--- a/docs/porting/security/TLS-on-PSA.md
+++ b/docs/porting/security/TLS-on-PSA.md
@@ -5,7 +5,7 @@
 The version of Mbed TLS shipped in Mbed OS builds with PSA enabled by default. However, you can build a PSA-enabled version of Mbed TLS from [our Git repository](https://github.com/ARMmbed/mbedtls):
 
 1. Clone the repository and switch to the `master` branch.
-1. Enable the `MBEDTLS_USE_PSA_CRYPTO` build-time configuration option in `include/mbedtls/config.h`, either by editing the file manually, or using the config script: `scripts/config.pl set MBEDTLS_USE_PSA_CRYPTO`.
+1. Enable the `MBEDTLS_USE_PSA_CRYPTO` build-time configuration option in `include/mbedtls/config.h`, either by editing the file manually, or using the config script: `scripts/config.py set MBEDTLS_USE_PSA_CRYPTO`.
 1. Build normally, for example (with GNU Make) `make lib` or (with CMake) `mkdir build && cd build && cmake .. && make lib`.
 
 ## Using PSA-enabled Mbed TLS


### PR DESCRIPTION
https://os.mbed.com/docs/mbed-os/v6.2/porting/using-psa-enabled-mbed-tls.html points to the `development-psa` branch of Mbed TLS. This was a temporary feature branch. The feature has long been merged into mainstream Mbed TLS. Update instructions accordingly.

This patch should also be made to the documentation for older versions of Mbed OS.
