### PR TITLE
Add Azure and Google Cloud repo URL in docs reference

### DIFF
--- a/docs/introduction/tutorials_intro.md
+++ b/docs/introduction/tutorials_intro.md
@@ -55,9 +55,9 @@ These tutorials show you how to install, export a project to and start a debuggi
 ## Connecting to the cloud
 
 - [Pelion Device Management](https://github.com/ARMmbed/mbed-os-example-pelion)
-- [AWS MQTT broker](https://github.com/ARMmbed/mbed-os-example-for-aws)
-- [Azure IoT Hub](https://github.com/ARMmbed/mbed-os-example-for-azure)
-- [Google Cloud IoT core](https://github.com/ARMmbed/mbed-os-example-for-google-iot-cloud)
+- [Mbed OS example for AWS IoT SDK](https://github.com/ARMmbed/mbed-os-example-for-aws)
+- [Mbed OS example for Azure IoT Hub](https://github.com/ARMmbed/mbed-os-example-for-azure)
+- [Mbed OS example for Google IoT Cloud](https://github.com/ARMmbed/mbed-os-example-for-google-iot-cloud)
 
 ## Migrating
 

--- a/docs/introduction/tutorials_intro.md
+++ b/docs/introduction/tutorials_intro.md
@@ -56,6 +56,8 @@ These tutorials show you how to install, export a project to and start a debuggi
 
 - [Pelion Device Management](https://github.com/ARMmbed/mbed-os-example-pelion)
 - [AWS MQTT broker](https://github.com/ARMmbed/mbed-os-example-for-aws)
+- [Azure IoT Hub](https://github.com/ARMmbed/mbed-os-example-for-azure)
+- [Google Cloud IoT core](https://github.com/ARMmbed/mbed-os-example-for-google-iot-cloud)
 
 ## Migrating
 


### PR DESCRIPTION
- Added Azure and Google Cloud repo URL under the cloud connector docs section.