### PR TITLE
Fix inconsistency in Arm Compiler version

### DIFF
--- a/docs/tools/tools_intro.md
+++ b/docs/tools/tools_intro.md
@@ -29,7 +29,7 @@ You can build Mbed OS with the Arm Compiler and GNU Arm Embedded toolchains. The
 
 | Compiler| Download location | Name in Mbed CLI |
 | --- | --- | --- |
-| Arm Compiler 6.14 (default ARM toolchain) | - A paid version is available as [Arm Compiler 6.13 Professional](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6). </br> - A paid version is also included in [Keil MDK 5.29](http://www2.keil.com/mdk5/529) | `ARM` |
+| Arm Compiler 6.14 (default ARM toolchain) | - A paid version is available as [Arm Compiler 6.14 Professional](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler/downloads/version-6). </br> - A paid version is also included in [Keil MDK 5.31](http://www2.keil.com/mdk5/531) | `ARM` |
 | GNU Arm Embedded version 9 (9-2019-q4-major) | [GNU Arm Embedded version 9 (9-2019-q4-major)](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) | `GCC_ARM` |
 
 <span class="notes">**Note**: Mbed OS 6 does not support Arm Compiler 5, IAR or uARM.</span>


### PR DESCRIPTION
The table documents the current Arm Compiler supported by Mbed OS to be 6.14, but the link text still says 6.13.
This PR fixes the inconsistency and updates the MDK version to 5.31 which contains Arm Compiler 6.14.