### PR TITLE
Document use of versioning tags on feature branches

### DIFF
--- a/docs/contributing/guidelines/workflow.md
+++ b/docs/contributing/guidelines/workflow.md
@@ -149,7 +149,9 @@ This can be any change in the functionality, including adding a new feature, a n
 
 A feature contribution contains a new API, capability or behavior. It does not break backward compatibility with existing APIs, capabilities or behaviors. New feature contributions are very welcome in Mbed OS. However, because they add capability to the codebase, a new feature may introduce bugs and a support burden. New features should also come with documentation, support for most targets and comprehensive test coverage. Feature PRs are treated cautiously, and new features require a new minor version for the codebase. 
 
-We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers or Mbed OS technical leads may create the new branches by following the naming convention: "feature-" prefix.
+We initially implement new features on separate branches in the Mbed OS repository. Mbed OS maintainers or Mbed OS technical leads may create the new branches by following the naming convention: "feature-" prefix. A feature branch exists as long as the feature is in development; when it is ready for release, the branch will be merged back into the Mbed OS release branch. This does not happen in some cases, instead, tags are used to informally release the feature on the branch.
+
+
 
 Each feature has a Mbed OS technical lead. This person is responsible for:
 
@@ -238,7 +240,7 @@ Maintainers merge pull requests because they have write access to the main maste
 
 ### Releases
 
-When we merge a pull request that we will publish in a patch release, we tag it with the specific patch release version. This is the release in which we first publish this pull request. For patch releases, we allow only bug fixes, new targets and enhancements to existing functionality. New features are only published in feature releases.
+When we merge a pull request that we will publish in a patch release, we tag it with the specific patch release version. This is the release in which we first publish this pull request. For patch releases, we allow only bug fixes, new targets and enhancements to existing functionality. New features are typically published in feature releases.
 
 The release tag has the format:
 

--- a/docs/introduction/release_process.md
+++ b/docs/introduction/release_process.md
@@ -23,6 +23,7 @@ They can include:
 - Deprecation of functionality (with an alternative functionality provided).
 - Configuration changes.
 
+Occasionally, new features aren't added directly through a feature release. Instead, a tag is created on the feature branch to informally release the feature. Tags are prefixed with "feature-" and follow the semantic versioning convention.
 ## Patch release
 
 Patch releases occur on the third Wednesday of every month. They are also backward compatible (source compatible). The last digit in the release number indicates the patch release. In Mbed OS 5.2.3, `3` shows the patch release is the third release in Mbed 5.2.
@@ -46,7 +47,7 @@ Two weeks before each feature release, we implement a code freeze on the master 
 
 For patch releases, code freeze occurs the Thursday before the release. Patch releases also go through exporter tests and nightly CI tests.
 
-After all tests return no errors, we release the latest updates. You can find the most recent release in the `mbed-os` repository with the `latest` tag. A release note accompanies each release. The release notes for major and feature releases are longer and give an overview of the new features. The release notes for the patch releases include only a list of changes and known issues, if applicable. You can find our release notes on [the releases page](https://os.mbed.com/releases/) and on [the blog](https://os.mbed.com/blog/).
+After all tests return no errors, we release the latest updates. You can find the most recent release in the `latest` branch of the `mbed-os` repository. A release note accompanies each release. The release notes for major and feature releases are longer and give an overview of the new features. The release notes for the patch releases include only a list of changes and known issues, if applicable. You can find our release notes on [the releases page](https://os.mbed.com/releases/) and on [the blog](https://os.mbed.com/blog/).
 
 ## The API life cycle
 


### PR DESCRIPTION
#### Changes 

- Add note regarding release of features on feature branches when branch hasn't been merged with Mbed OS Release branch. Tags follow semantic versioning convention i.e. feature-wisun-1.2.0.
- Update documentation to show that "latest" is not longer a tag but a branch that the release points to.

### Reviewers
@0xc0170 