### PR TITLE
docs: Add description about flash option

### DIFF
--- a/docs/tools/mbed_cli_2/use.md
+++ b/docs/tools/mbed_cli_2/use.md
@@ -178,6 +178,14 @@ To perform an iterative build on a previously configured project:
 mbed-tools build
 ```
 
+## Flashing the built program
+
+You can flash the built program to the connected target by adding the -f/--flash argument to the compile command:
+
+```
+mbed-tools compile -f
+```
+
 ## List an application's library dependencies
 
 To list all library dependencies with their URL and Git reference:


### PR DESCRIPTION
If `mbedtools compile` command is invoked with `-f/--flash` option then
the built binary will be flashed onto the connected device.