### PR TITLE
mbed-cli-2: Remove documentation for libs command

### DIFF
--- a/docs/tools/mbed_cli_2/use.md
+++ b/docs/tools/mbed_cli_2/use.md
@@ -178,14 +178,6 @@ To perform an iterative build on a previously configured project:
 mbed-tools build
 ```
 
-## List an application's library dependencies
-
-To list all library dependencies with their URL and Git reference:
-
-```
-mbed-tools libs
-```
-
 ## Logging
 
 To specify the log level, use the verbose logging option (`-v`) before the first argument:


### PR DESCRIPTION
The `libs` command was removed from mbed-cli-2.