### PR TITLE
Mbed CLI 2 - Update with support for multiple targets

### DIFF
--- a/docs/tools/mbed_cli_2/use.md
+++ b/docs/tools/mbed_cli_2/use.md
@@ -139,7 +139,7 @@ The Mbed OS configuration system parses the configuration files in your project 
 
     ```
     mbed-tools configure -m K64F -t GCC_ARM
-    mbed_config.cmake has been generated and written to '/Users/UserName/Development/Blinky/.mbedbuild'
+    mbed_config.cmake has been generated and written to '/Users/UserName/Development/Blinky/cmake_build/K64F/develop/GCC_ARM/mbed_config.cmake'
     ```
 
 ## Build the project

--- a/docs/tools/mbed_cli_2/use.md
+++ b/docs/tools/mbed_cli_2/use.md
@@ -186,11 +186,19 @@ Example for FRDM-K64F and GCC:
 mbed-tools compile -m K64F -t GCC_ARM
 ```
 
+### Building for multiple targets
+
+You can build an Mbed project for multiple targets, with different profiles and toolchains, without affecting other builds. The `compile` subcommand will create and build into a different subdirectory for each combination:
+
+```
+cmake_build/<target>/<profile>/<toolchain>/
+```
+
 ## Iterative builds on configured projects
 
 If you have already made a build for the Mbed target and toolchain that you're using, `compile` will perform an iterative build.
 
-To force a rebuild of the project, include the --clean argument:
+To force a rebuild of the project for a target and toolchain, include the --clean argument:
 
 ```
 mbed-tools compile -m <target> -t <toolchain> --clean

--- a/docs/tools/mbed_cli_2/use.md
+++ b/docs/tools/mbed_cli_2/use.md
@@ -188,10 +188,12 @@ mbed-tools compile -m K64F -t GCC_ARM
 
 ## Iterative builds on configured projects
 
-To perform an iterative build on a previously configured project:
+If you have already made a build for the Mbed target and toolchain that you're using, `compile` will perform an iterative build.
+
+To force a rebuild of the project, include the --clean argument:
 
 ```
-mbed-tools compile
+mbed-tools compile -m <target> -t <toolchain> --clean
 ```
 
 ## Flashing the built program
@@ -199,7 +201,7 @@ mbed-tools compile
 You can flash the built program to the connected target by adding the -f/--flash argument to the compile command:
 
 ```
-mbed-tools compile -f
+mbed-tools compile -m <target> -t <toolchain> -f
 ```
 
 ## Opening a serial terminal


### PR DESCRIPTION
As Mbed CLI 2 now supports building for multiple targets in subdirectories, its useful to document this behavior.

In addition, as target and toolchain arguments are now required with `compile`, these have been added where needed. And a minor change has also been made to correct the message shown for the `configure` example.