### PR TITLE
Update FPGA documentation

### DIFF
--- a/docs/porting/target/static_pinmap.md
+++ b/docs/porting/target/static_pinmap.md
@@ -172,7 +172,7 @@ Run FPGA tests to check whether your implementation is valid:
 mbed test -n "hal-tests-tests*fpga*" --app-config TESTS/configs/fpga.json
 ```
 
-The `FPGA_FORCE_ALL_PORTS` macro can be defined to force all peripherals to be tested. Some FPGA tests only test one by default, to save time.
+The `FPGA_FORCE_ALL_PORTS` macro can be defined to force all pinouts of all peripherals to be tested. Some FPGA tests only test one pinout of one peripheral by default, to save time.
 
 ```
 mbed test -n "hal-tests-tests*fpga*" --app-config TESTS/configs/fpga.json -DFPGA_FORCE_ALL_PORTS

--- a/docs/porting/target/static_pinmap.md
+++ b/docs/porting/target/static_pinmap.md
@@ -174,4 +174,8 @@ mbed test -n "hal-tests-tests*fpga*" --app-config TESTS/configs/fpga.json
 
 The `FPGA_FORCE_ALL_PORTS` macro can be defined to force all peripherals to be tested. Some FPGA tests only test one by default, to save time.
 
+```
+mbed test -n "hal-tests-tests*fpga*" --app-config TESTS/configs/fpga.json -DFPGA_FORCE_ALL_PORTS
+```
+
 <span class="notes">**Note:** Your target must be ready to run FPGA Test Shield tests.</span>

--- a/docs/porting/target/static_pinmap.md
+++ b/docs/porting/target/static_pinmap.md
@@ -169,7 +169,9 @@ Total flash memory (text + data): 44554(-1010) bytes
 Run FPGA tests to check whether your implementation is valid:
 
 ```
- mbed test -t ARM -m K64F -n tests-mbed_hal_fpga_ci_test_shield*
+mbed test -n "hal-tests-tests*fpga*" --app-config TESTS/configs/fpga.json
 ```
+
+The `FPGA_FORCE_ALL_PORTS` macro can be defined to force all peripherals to be tested. Some FPGA tests only test one by default, to save time.
 
 <span class="notes">**Note:** Your target must be ready to run FPGA Test Shield tests.</span>


### PR DESCRIPTION
This PR updates the command to run FPGA tests in documentation and adds info about the `FPGA_FORCE_ALL_PORTS` macro.