### PR TITLE
Remove TDB_EXTERNAL_NO_RBP and FILESYSTEM_NO_RBP from KVStore docs

### DIFF
--- a/docs/api/storage/KVStoreGlobalAPI.md
+++ b/docs/api/storage/KVStoreGlobalAPI.md
@@ -26,7 +26,7 @@ You can "or" (|) the flags below and pass them to the function set in the parame
 
 - **KV_WRITE_ONCE_FLAG:** The system does not an additional call to the function set with the same file name to delete or replace data.
 - **KV_REQUIRE_CONFIDENTIALITY_FLAG:** The system encrypts the data using an AES CTR, a random IV and a key derived from DeviceKey. This flag will be ignored if you select the `TDB_INTERNAL` configuration because the internal memory is seen as protected from physical attacks.
-- **KV_REQUIRE_REPLAY_PROTECTION_FLAG:** The system keeps a copy of the data CMAC in internal memory and checks that the data CMAC corresponds to this saved CMAC. It does this to prevent an attacker replacing the latest data with a valid old version of the data. This flag will be ignored if you select the configuration `TDB_EXTERNAL_NO_RBP` or `FILESYSTEM_NO_RBP`.
+- **KV_REQUIRE_REPLAY_PROTECTION_FLAG:** The system keeps a copy of the data CMAC in internal memory and checks that the data CMAC corresponds to this saved CMAC. It does this to prevent an attacker replacing the latest data with a valid old version of the data.
 
 ### `full_prefix`
 


### PR DESCRIPTION
Preceeding PR: https://github.com/ARMmbed/mbed-os/pull/14490

NO_RBP (no rollback protection) is intended to not require an internal
TDB, however, DeviceKey, which we use to derive SecureStore's
encryption key, still does. Currently, no internal TDB is created with
these two configurations, meaning there's no way to store the DeviceKey
and SecureStore doesn't work.

Update the documentation to reflect these changes.