### PR TITLE
Remove deprecated bootloader examples

### DIFF
--- a/deprecated/examples.md
+++ b/deprecated/examples.md
@@ -45,11 +45,6 @@ A few micro:bit How To videos:
 
 [Get the FAT file system working on an Mbed OS platform](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-fat-filesystem/).
 
-#### Bootloader
-
-- [Create a bootloader](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-bootloader/).
-- [Use a blinky application with a prebuilt bootloader](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-bootloader-blinky/).
-
 ### mbed Client
 
 [Getting started](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-client/): a basic example of mbed Client for Mbed OS. It demonstrates how to register a device with Mbed Device Connector, how to read and write values and how to deregister.

--- a/docs/api/drivers/FlashIAP.md
+++ b/docs/api/drivers/FlashIAP.md
@@ -28,4 +28,4 @@ View the full C++ API:
 
 ## Flash IAP example
 
-For an example that uses the `FlashIAP` driver, please see the [bootloader example](https://github.com/ARMmbed/mbed-os-example-bootloader).
+For a program that uses the `FlashIAP` driver, please see the [Mbed Stress Test](https://github.com/ARMmbed/mbed-stress-test).

--- a/docs/introduction/tutorials_intro.md
+++ b/docs/introduction/tutorials_intro.md
@@ -49,7 +49,6 @@ These tutorials show you how to install, export a project to and start a debuggi
 ## Bootloader
 
 - [A tutorial for creating and using a bootloader](../program-setup/creating-and-using-a-bootloader.html).
-- [An official example of bootloader implementation](https://github.com/ARMmbed/mbed-os-example-bootloader).
 
 ## Connecting to the cloud
 

--- a/docs/program-setup/concepts/managed-unmanaged-bootloader.md
+++ b/docs/program-setup/concepts/managed-unmanaged-bootloader.md
@@ -78,8 +78,6 @@ Call the bootloader to start the main program:
 mbed_start_application(POST_APPLICATION_ADDR);
 ```
 
-For an example showing how to create a bootloader, see the [mbed-os-example-bootloader](https://github.com/armmbed/mbed-os-example-bootloader) repository.
-
 ### Creating the main program
 
 To create an application using a bootloader, you must first have created the bootloader binary and added it to the current project. You must then specify the bootloader image in `mbed_app.json` in the `target_override` section:
@@ -181,8 +179,6 @@ You can add the BOOTLOADER feature into `mbed_app.json` located in the root appl
    ```
 
 Alternatively, you can add `-C 'target.features_add=["BOOTLOADER"]'` to your `mbed compile` command-line arguments.
-
-Please see the [bootloader example](https://github.com/ARMmbed/mbed-os-example-bootloader) for an example on how to use the bootloader feature.
 
 There are two ways to add support for new targets:
 


### PR DESCRIPTION
Remove mentions of mbed-os-example-bootloader and
mbed-os-example-bootloader-blinky, both of which are deprecated
examples.