### PR TITLE
Workaround for Python requests library not handling redirections properly

### DIFF
--- a/docs/api/platform/time/Wait.md
+++ b/docs/api/platform/time/Wait.md
@@ -10,7 +10,7 @@ The wait_us and wait_ns functions provide precise wait capabilities. These funct
 
 ## Example
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/wait_ex_1/)](https://os.mbed.com/teams/mbed_example/code/wait_ex_1/file/4f0543415053/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/wait_ex_1/)](https://os.mbed.com/teams/mbed_example/code/wait_ex_1/file/4f0543415053/main.cpp/)
 
 ## Related content
 


### PR DESCRIPTION
One of our snippets URL is redirected to the same URL with a trailing slash `/`. When fetched by the requests Python library in the docs engine, the trailing slash is not taken into account leading to unlimited redirects.

Adding the slash to the URL in the relevant Markdown file fixes the issue.