### PR TITLE
Chris dev

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,7 +8,7 @@
             "hidden": true,
             "type": "doxygen",
             "source": "https://github.com/ARMmbed/mbed-os",
-            "branch": "mbed-os-6.11.0-docs-utf-8-fix"
+            "branch": "master"
         },
         {
             "title": "Introduction to Mbed OS 6",

--- a/docs.json
+++ b/docs.json
@@ -8,7 +8,7 @@
             "hidden": true,
             "type": "doxygen",
             "source": "https://github.com/ARMmbed/mbed-os",
-            "branch": "master"
+            "branch": "mbed-os-6.11.0-docs-utf-8-fix"
         },
         {
             "title": "Introduction to Mbed OS 6",

--- a/docs/api/connectivity/networksocket/socket.md
+++ b/docs/api/connectivity/networksocket/socket.md
@@ -38,5 +38,5 @@ Here is a client example of HTTP transaction over TCPSocket or TLSSocket:
 
 - [TCPSocket](tcpsocket.html) API reference.
 - [UDPSocket](udpsocket.html) API reference.
-- [TLSSocket](../secure-socket/tlssocket.html) API reference.
+- [TLSSocket](tlssocket.html) API reference.
 - [Socket](../apis/connectivity-architecture.html#socket-api) architecture.

--- a/docs/introduction/introduction.md
+++ b/docs/introduction/introduction.md
@@ -24,7 +24,7 @@ Our [quick start](../quick-start/index.html) guides show how to build an example
 
 ## Recently updated documentation
 
-- A new [Mbed CLI1 to CLI2 migration guide](../tools/mbed_cli_2/migration_guide.md).
+- A new [Mbed CLI1 to CLI2 migration guide](../build-tools/migration-guide.html).
 - A new [tutorial about link time optimization](../apis/link-time-optimization.html).
 - A new [PSA porting guide](../porting/porting-security.html).
 - New information about [API life cycle ](../introduction/versions-and-releases.html#the-api-life-cycle) and how to [contribute experimental APIs](../contributing/software-design.html#experimental-apis) and [use them in an application](../program-setup/build-rules.html#label-directories).

--- a/docs/introduction/introduction.md
+++ b/docs/introduction/introduction.md
@@ -24,6 +24,7 @@ Our [quick start](../quick-start/index.html) guides show how to build an example
 
 ## Recently updated documentation
 
+- A new [Mbed CLI1 to CLI2 migration guide](../tools/mbed_cli_2/migration_guide.md).
 - A new [tutorial about link time optimization](../apis/link-time-optimization.html).
 - A new [PSA porting guide](../porting/porting-security.html).
 - New information about [API life cycle ](../introduction/versions-and-releases.html#the-api-life-cycle) and how to [contribute experimental APIs](../contributing/software-design.html#experimental-apis) and [use them in an application](../program-setup/build-rules.html#label-directories).

--- a/docs/porting/target/gpio.md
+++ b/docs/porting/target/gpio.md
@@ -2,4 +2,4 @@
 
 Implement the api declared in `mbed-os/hal/gpio_api.h`. You must define the struct `gpio_t`. This struct is commonly defined in an `objects.h` file within the `mbed-os/targets/TARGET_VENDOR/`, `mbed-os/targets/TARGET_VENDOR/TARGET_MCU_FAMILY` or `mbed-os/targets/TARGET_VENDOR/TARGET_MCU_FAMILY/TARGET_MCUNAME` directories.
 
-You should define the GPIO names for LEDS and switches in PinNames.h as defined in the porting guide for pin names [here](../standard_pin_names/pin_names_porting.md).
+You should define the GPIO names for LEDs and switches in PinNames.h as defined in the porting guide for pin names [here](standard-pin-names.html).

--- a/docs/tools/mbed_cli_2/migration_guide.md
+++ b/docs/tools/mbed_cli_2/migration_guide.md
@@ -1,6 +1,6 @@
 # Migration guide
 
-If you haven't already read the [introduction](./intro.md), then start from there.
+If you haven't already read the [Mbed CLI 2 introduction](intro.md), then start there.
 
 The background color indicates:
 

--- a/docs/tools/mbed_cli_2/migration_guide.md
+++ b/docs/tools/mbed_cli_2/migration_guide.md
@@ -1,6 +1,6 @@
 # Migration guide
 
-If you haven't already read the [Mbed CLI 2 introduction](intro.md), then start there.
+If you haven't already read the [Mbed CLI 2 introduction](mbed-cli-2.html), then start there.
 
 The background color indicates:
 


### PR DESCRIPTION
Fix for two broken links in content (that have been there a while) found when running linkchecker on 6.11 docs.

Also temporary fix for docs.json to point to mbed-os-6.11.0-docs-utf-8-fix for doxygen output, as a workaround for the problem with non UTF-8 character preventing builds.