### PR TITLE
Docs fixes (#1468)

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -240,12 +240,10 @@ Connectivity APIs include:
 
 | API | Full profile | Bare metal profile |
 | - | - | - |
-| [BatteryService](../apis/bluetooth-apis.html) | &#10004; | &#10004; (can be manually enabled) |
-| [BLE](../apis/ble.html) | &#10004; | &#10004; (can be manually enabled) |
+| [BLE](../apis/bluetooth-apis.html) | &#10004; | &#10004; (can be manually enabled) |
 | [GAP](../apis/gap.html) | &#10004; | &#10004; (can be manually enabled) |
 | [GattClient](../apis/gattclient.html) | &#10004; | &#10004; (can be manually enabled) |
 | [GattServer](../apis/gattserver.html) | &#10004; | &#10004; (can be manually enabled) |
-| [HeartRateService](../apis/heartrateservice.html) | &#10004; | &#10004; (can be manually enabled) |
 | [SecurityManager](../apis/securitymanager.html) | &#10004; | &#10004; (can be manually enabled) |
 
 ### NFC

--- a/docs/api/connectivity/connectivity-arch.md
+++ b/docs/api/connectivity/connectivity-arch.md
@@ -57,7 +57,7 @@ BLE is optimized for cheap, battery-based devices and has a low memory footprint
 
 Typical applications of BLE are health care, fitness trackers, beacons, smart homes, security, entertainment, proximity sensors, industrial applications and automotives.
 
-To learn how to use BLE on Mbed OS, please refer to the [Bluetooth overview](../apis/ble.html).
+To learn how to use BLE on Mbed OS, please refer to the [Bluetooth overview](../apis/bluetooth-apis.html).
 
 ### 6LoWPAN Mesh
 

--- a/docs/api/connectivity/connectivity_list.md
+++ b/docs/api/connectivity/connectivity_list.md
@@ -28,12 +28,10 @@
 
 ## Bluetooth (BLE)
 
-- [BatteryService](../apis/bluetooth-apis.html): Report battery charge levels to the user.
-- [BLE](../apis/ble.html): Interface with the BLE controller on the board.
+- [BLE](../apis/bluetooth-apis.html): Interface with the BLE controller on the board.
 - [GAP](../apis/gap.html): Handle connectivity tasks.
 - [GattClient](../apis/gattclient.html): Initiate interactions with a GattServer to discover services, characteristics and descriptors and perform operations on them.
 - [GattServer](../apis/gattserver.html): Respond to a GattClient.
-- [HeartRateService](../apis/heartrateservice.html): Expose heart rate sensor data in a Bluetooth standard compliant way.
 - [SecurityManager](../apis/securitymanager.html): Use pairing and optional bonding processes to authenticate and encrypt BLE links.
 
 ## NFC

--- a/docs/introduction/terms.md
+++ b/docs/introduction/terms.md
@@ -22,7 +22,7 @@
 
 **Bit** - A basic unit of digital information that can be one of two values: `0` (`false`) or `1` (`true`).
 
-**BLE** - [Bluetooth Low Energy](../apis/ble.html).
+**BLE** - [Bluetooth Low Energy](../apis/bluetooth-apis.html).
 
 **Blinky** - An [example application](../quick-start/index.html) that you can use to get to know Arm Mbed OS and the development tools. It’s one of the simplest examples of Mbed OS.
 


### PR DESCRIPTION
* update intro section to refer to new BLE optimiztion section, correct spelling (optimise/optimize etc.) in various places for consitency (including a filename change), and minor improvements to wording in new BLE topics.

* correct filepath

* correct link / link text

* further edits relating to https://github.com/ARMmbed/mbed-os-5-docs/pull/1458/ - battry and heart rate services were deprecated/removed but some links remained

* remove another outdated link to battery service