### PR TITLE
mbed-cli 2: all targets are supported

### DIFF
--- a/docs/tools/mbed_cli_2/use.md
+++ b/docs/tools/mbed_cli_2/use.md
@@ -1,7 +1,5 @@
 # Use
 
-Currently, Mbed CLI 2 supports three boards: `K64F`, `DISCO_L475VG_IOT01A` and `NRF52840_DK`.
-
 For help:
 
 - To get help for all commands, use:


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-os-5-docs/issues/1470