### PR TITLE
correct links to Mbed TLS .h files (use MbedOS specific versions)

### DIFF
--- a/docs/api/security/TLS.md
+++ b/docs/api/security/TLS.md
@@ -22,7 +22,7 @@ Each of them comes with complete usage instructions as a readme file in the repo
 
 ## Configuring Mbed TLS features
 
-Mbed TLS simplifies enabling and disabling features to meet the needs of a particular project, through compilation options. The list of compilation flags is available in the fully documented configuration file, [config.h](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/config.h).
+Mbed TLS simplifies enabling and disabling features to meet the needs of a particular project, through compilation options. The list of compilation flags is available in the fully documented configuration file, [config.h](https://github.com/ARMmbed/mbed-os/blob/master/connectivity/mbedtls/include/mbedtls/config.h).
 
 For example, in an application called `myapp`, if you want to enable the EC J-PAKE key exchange and disable the CBC cipher mode, you can create a file named  `mbedtls-config-changes.h` in the `myapp` directory containing the following lines:
 

--- a/docs/porting/security/hw-accelerated-crypto.md
+++ b/docs/porting/security/hw-accelerated-crypto.md
@@ -16,7 +16,7 @@ You may want to add hardware acceleration in the following cases:
 
 - Your platform has a dedicated crypto-module capable of executing cryptographic primitives, and possibly storing keys securely.
 
-The Mbed TLS library was written in C and it has a small amount of hand-optimized assembly code, limited to arbitrary precision multiplication on some processors. You can find the list of supported platforms in the top comment in [bn_mul.h](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/bn_mul.h).
+The Mbed TLS library was written in C and it has a small amount of hand-optimized assembly code, limited to arbitrary precision multiplication on some processors. You can find the list of supported platforms in the top comment in [bn_mul.h](https://github.com/ARMmbed/mbed-os/blob/master/connectivity/mbedtls/include/mbedtls/bn_mul.h).
 
 ### What parts can I accelerate?
 


### PR DESCRIPTION
previous links to .h files were broken following changes in TLS project development branch