### PR TITLE
Netsocket: mention control versions of sendto/recvfrom.

### DIFF
--- a/docs/api/connectivity/arch/securesocket-arch.md
+++ b/docs/api/connectivity/arch/securesocket-arch.md
@@ -109,9 +109,11 @@ virtual nsapi_size_or_error_t send(const void *data, nsapi_size_t size);
 virtual nsapi_size_or_error_t recv(void *data, nsapi_size_t size);
 virtual nsapi_size_or_error_t sendto(const SocketAddress &address, const void *data, nsapi_size_t size);
 virtual nsapi_size_or_error_t recvfrom(SocketAddress *address, void *data, nsapi_size_t size);
+virtual nsapi_size_or_error_t sendto_control(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size, nsapi_msghdr_t *control, nsapi_size_t control_size);
+virtual nsapi_size_or_error_t recvfrom_control(nsapi_socket_t handle, SocketAddress *address, void *data, nsapi_size_t size, nsapi_msghdr_t *control, nsapi_size_t control_size);
 ```
 
-These work as expected, but `SocketAddress` parameters are ignored. The TLS connection cannot change the peer. Also, `recvfrom()` call does not set the peer address.
+These work as expected, but `SocketAddress` parameters are ignored. The TLS connection cannot change the peer. Also, `recvfrom()` and `recvfrom_control()` call does not set the peer address.
 
 Mbed TLS error codes `MBEDTLS_ERR_SSL_WANT_READ` and `MBEDTLS_ERR_SSL_WANT_WRITE` are translated to `NSAPI_ERROR_WOULD_BLOCK` before passing to user.
 

--- a/docs/api/connectivity/networksocket/UDPSocket.md
+++ b/docs/api/connectivity/networksocket/UDPSocket.md
@@ -2,7 +2,7 @@
 
 <span class="images">![](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/class_u_d_p_socket.png)<span>UDPSocket class hierarchy</span></span>
 
-The UDPSocket class provides the ability to send packets of data over UDP, using the `sendto` and `recvfrom` member functions. Packets can be lost or arrive out of order, so we suggest using a [TCPSocket](../apis/tcpsocket.html) when you require guaranteed delivery.
+The UDPSocket class provides the ability to send packets of data over UDP, using the `sendto`/`sendto_control` and `recvfrom`/`recvfrom_control` member functions. Packets can be lost or arrive out of order, so we suggest using a [TCPSocket](../apis/tcpsocket.html) when you require guaranteed delivery.
 
 The constructor takes no parameters. To initialize the socket on a specified NetworkInterface, you must call `open` method, which takes a NetworkStack pointer.
 

--- a/docs/api/connectivity/networksocket/socket.md
+++ b/docs/api/connectivity/networksocket/socket.md
@@ -16,6 +16,8 @@ The Socket class defines the Mbed OS Socket API and loosely follows the POSIX st
 | `Socket::recv()`     | Receive data from a socket | [recv](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html) |
 | `Socket::sendto()`   | Sends data to the specified address. | [sendto](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html) |
 | `Socket::recvfrom()` | Receives data and stores the source address | [recvfrom](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html) |
+| `Socket::sendto_control()`   | Similar to `sendto` but support message control through ancilary data. | [sendto](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html), [sendmsg](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html) |
+| `Socket::recvfrom_control()` | Similar to `recvfrom` but support message control through ancilary data. | [recvfrom](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html), [sendmsg](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html) |
 | `Socket::bind()`     | Bind a specific address to a socket | [bind](http://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html) |
 | `Socket::listen()`   | Listen for incoming connections | [listen](http://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html) |
 | `Socket::accept()`   | Accept incoming connection | [accept](http://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html) |

--- a/docs/porting/connectivity/NetworkStack.md
+++ b/docs/porting/connectivity/NetworkStack.md
@@ -66,7 +66,9 @@ nsapi_error_t socket_accept(nsapi_socket_t server, nsapi_socket_t *handle, Socke
 nsapi_size_or_error_t socket_send(nsapi_socket_t handle, const void *data, nsapi_size_t size);
 nsapi_size_or_error_t socket_recv(nsapi_socket_t handle, void *data, nsapi_size_t size);
 nsapi_size_or_error_t socket_sendto(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size);
+nsapi_size_or_error_t socket_sendto_control(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size, nsapi_msghdr_t *control, nsapi_size_t control_size);
 nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t handle, SocketAddress *address, void *buffer, nsapi_size_t size);
+nsapi_size_or_error_t socket_recvfrom_control(nsapi_socket_t handle, SocketAddress *address, void *data, nsapi_size_t size, nsapi_msghdr_t *control, nsapi_size_t control_size);
 nsapi_error_t setsockopt(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen);
 nsapi_error_t getsockopt(nsapi_socket_t handle, int level, int optname, void *optval, unsigned *optlen);
 ```


### PR DESCRIPTION
This change will be required when https://github.com/ARMmbed/mbed-os/pull/15040 lands as new APIs have been added to the Socket class.
The link to the relevant POSIX documentation is provided. Similar to other functions. 