### PR TITLE
Add info about 8bit address format

### DIFF
--- a/docs/api/drivers/I2CSlave.md
+++ b/docs/api/drivers/I2CSlave.md
@@ -4,7 +4,11 @@ Use I2C Slave to communicate with I2C Master.
 
 Synchronization level: not protected.
 
+<span class="notes">**Note:** Remember that you need a pull-up resistor on sda and scl. All drivers on the I2C bus are required to be open collector, and so it is necessary to use pull-up resistors on the two signals. A typical value for the pull-up resistors is around 2.2k ohms, connected between the pin and 3v3. </span>
+
 ## I2CSlave class reference
+
+<span class="notes">**Note:** The Arm Mbed API uses 8 bit addresses, so make sure to left-shift 7 bit addresses by 1 bit before passing them. </span>
 
 [![View code](https://www.mbed.com/embed/?type=library)](https://os.mbed.com/docs/mbed-os/development/mbed-os-api-doxy/classmbed_1_1_i2_c_slave.html)
 


### PR DESCRIPTION
There is not much clear info about the I2CSlave API also uses 8bit format and need to be bit shifted. It can be confusing for a novice.
So I suggest copying same info like is on I2C API page.