### PR TITLE
fix a syntax error on a link on DAP.md

### DIFF
--- a/docs/debugging-testing/debug/DAP.md
+++ b/docs/debugging-testing/debug/DAP.md
@@ -2,7 +2,7 @@
 
 DAPlink is an open source project that implements the embedded firmware required for a Cortex debug probe. The project is hosted on GitHub and is published under an Apache 2.0 license, making it attractive for commercial developments.
 
-The software project is complemented by a series of reference designs for creating the DAPLink debug probe hardware, which is available in the [HDK documentation]../porting/porting-tools.html#arm-mbed-hdk).
+The software project is complemented by a series of reference designs for creating the DAPLink debug probe hardware, which is available in the [HDK documentation](../../porting/porting-tools.html#arm-mbed-hdk).
 
 ## DAPLink features
 


### PR DESCRIPTION
This fixes a syntax error visible on https://os.mbed.com/docs/mbed-os/v6.15/debug-test/daplink.html (second paragraph).

I assume the navigation across `.md` files follow the navigation across `.html` files, replacing `../` by `../../` as well.