### PR TITLE
[DSGECO-375] redirects.json updated to resolve troubleshooting broken link

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -177,5 +177,7 @@
     "apis/mesh.html" : "apis/mesh-api.html",
     "apis/dns.html" : "apis/dns-apis.html",
     "porting/psa-compliance-port.html" : "porting/porting-security.html",
-    "build-tools/mbed-cli.html" : "build-tools/mbed-cli-1.html"
+    "build-tools/mbed-cli.html" : "build-tools/mbed-cli-1.html",
+    "tutorials/debugging-applications.html" : "debug-test/troubleshooting-common-issues.html",
+    "mbed-os/v6.0/contributing/index.html" : "mbed-os/latest/contributing/index.html"
 }


### PR DESCRIPTION
On this page, https://os.mbed.com/support/, the [troubleshooting section of the website](https://os.mbed.com/docs/latest/tutorials/debugging-applications.html) link is broken. This should point to https://os.mbed.com/docs/mbed-os/latest/debug-test/troubleshooting-common-issues.html

Redirects.json updated.